### PR TITLE
facts, class to stop failing rspec tests

### DIFF
--- a/spec/defines/template_spec.rb
+++ b/spec/defines/template_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe 'elasticsearch::template', :type => 'define' do
 
   let(:title) { 'foo' }
+  let(:facts) { {:operatingsystem => 'CentOS' }}
+  let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}}'}
 
   context "Add a template" do
 


### PR DESCRIPTION
Adds a fact to stop failing rspec tests
Adds a pre_condition to define the elasticsearch config with the minimum required settings so that 'include elasticsearch' doesn't fail.
