### PR TITLE
add monitoring framework and sensu checks

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    sensu: git://github.com/sensu/sensu-puppet.git
     stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
     elasticsearch: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,10 @@
 # a look at the corresponding <tt>params.pp</tt> manifest file if you need more
 # technical information about them.
 #
+# [*monitoring*]
+#   What monitoring system should be used to monitor this node.  The available
+#   options can be found in the <tt>manifests/monitoring</tt> directory.
+#
 #
 # === Examples
 #
@@ -122,6 +126,7 @@ class elasticsearch(
   $java_install      = false,
   $java_package      = undef,
   $initfile          = undef,
+  $monitoring        = undef,
 ) inherits elasticsearch::params {
 
   #### Validate parameters

--- a/manifests/monitoring/sensu.pp
+++ b/manifests/monitoring/sensu.pp
@@ -1,0 +1,29 @@
+# == Class: elasticsearch::monitoring::sensu
+#
+# Adds sensu monitoring to elasticsearch hosts
+#
+#
+# === Authors
+#
+# * Justin Lambert <mailto:jlambert@letsevenup.com>
+#
+class elasticsearch::monitoring::sensu {
+
+  # Checking ES node and cluster health
+  sensu::check { 'es-status':
+    handlers    => 'default',
+    command     => '/etc/sensu/plugins/check-es-cluster-status.rb',
+    standalone  => true,
+  }
+
+  # Metrics
+  sensu::check { 'es-metrics':
+    type        => 'metric',
+    handlers    => 'graphite',
+    command     => '/etc/sensu/plugins/es-node-graphite.rb',
+    standalone  => true,
+  }
+
+  sensu::subscription { 'elasticsearch': }
+
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -104,4 +104,15 @@ class elasticsearch::service {
     provider   => $elasticsearch::params::service_provider,
   }
 
+  # Monitoring
+  if $service_enable {
+    case $elasticsearch::monitoring {
+      'sensu':  {
+        include elasticsearch::monitoring::sensu
+      }
+      default : {}
+    }
+  }
+
+
 }

--- a/spec/classes/elasticsearch_init_spec.rb
+++ b/spec/classes/elasticsearch_init_spec.rb
@@ -501,4 +501,28 @@ describe 'elasticsearch', :type => 'class' do
 
   end
 
+  context "monitoring" do
+
+    let :facts do {
+      :operatingsystem => 'CentOS'
+    } end
+
+    context "not set" do
+
+      it { should_not include_class('elasticsearch::monitoring::sensu') }
+
+    end
+
+    context "sensu" do
+      let :params do {
+        :config => { 'node' => { 'name' => 'test' }  },
+        :monitoring => 'sensu'
+        } end
+
+      it { should include_class('elasticsearch::monitoring::sensu') }
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
For production systems we have puppet automatically configure monitoring whenever a service is included on a node so it doesn't get forgotten.  I would like to add that to this module, but want to do it in a way that nobody is required to use it and it can easily support other solutions besides what we use.  

Thoughts on the approach?
