### PR TITLE
Move to using a sorted hash in the template to ensure that file's md5sum...

### DIFF
--- a/templates/etc/default/elasticsearch.erb
+++ b/templates/etc/default/elasticsearch.erb
@@ -1,5 +1,5 @@
 ### MANAGED BY PUPPET ###
 
-<% scope.lookupvar('elasticsearch::service_settings').each_pair do |key, value| -%>
+<% scope.lookupvar('elasticsearch::service_settings').sort.map do |key, value| -%>
 <%= key %>=<%= value %>
 <% end -%>


### PR DESCRIPTION
... doesn't randomly change each puppet run.
