### PR TITLE
respect restart_on_change on default/elasticsearch

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -28,6 +28,13 @@
 #
 class elasticsearch::service {
 
+  include elasticsearch
+
+  $notify_elasticsearch = $elasticsearch::restart_on_change ? {
+    true  => Class['elasticsearch::service'],
+    false => undef,
+  }
+
   #### Service management
 
   # set params: in operation
@@ -78,7 +85,7 @@ class elasticsearch::service {
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => Service['elasticsearch'],
+    notify  => $notify_elasticsearch,
   }
 
   if $elasticsearch::status != 'unmanaged' and $elasticsearch::initfile != undef {


### PR DESCRIPTION
when the /etc/default/elasticsearch file is changed the
Service['elasticsearch'] was triggered even if +restart_on_change+ is
false
