### PR TITLE
Retry the application of a template if it fails. 

### DIFF
--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -75,7 +75,9 @@ define elasticsearch::template(
     exec { 'insert_template':
       command     => "curl -s -XPUT ${es_url} -d @${elasticsearch::confdir}/templates/elasticsearch-template-${name}.json",
       unless      => "test $(curl -s '${es_url}?pretty=true' | wc -l) -gt 1",
-      refreshonly => true
+      refreshonly => true,
+      tries       => 3,
+      try_sleep   => 10
     }
   }
 }


### PR DESCRIPTION
This can happen if the service has been restarted just before the template is applied.
