### PR TITLE
puppet now arrives with validation turned on for Exec

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,7 +51,7 @@ class elasticsearch::config {
   }
 
   exec { 'mkdir_templates':
-    command => "mkdir -p ${elasticsearch::confdir}/templates_import",
+    command => "/bin/mkdir -p ${elasticsearch::confdir}/templates_import",
     cwd     => '/',
     creates => "${elasticsearch::confdir}/templates_import",
     path    => '/usr/bin:/bin',


### PR DESCRIPTION
exec validation doesn't like mkdir without absolute path
