### PR TITLE
fix scope deprecation error

### DIFF
--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -71,7 +71,7 @@
   # initial string
   @yml_string = "### MANAGED BY PUPPET ###\n"
 
-  if !settings.empty?
+  if !@settings.empty?
 
     @yml_string += "---\n"
 


### PR DESCRIPTION
Referencing variables within a template is deprecated in puppet 3, to be removed in puppet 4.

@varname or scope.lookupvar('varname') resolves this issue.  As far as I know both are backward-compatible with puppet 2.7.
