### PR TITLE
consistently set and use Exec defaults

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,11 @@ class elasticsearch::config {
 
   include elasticsearch
 
+  Exec {
+    path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    cwd  => '/',
+  }
+
   $settings = $elasticsearch::config
 
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {
@@ -52,8 +57,6 @@ class elasticsearch::config {
 
   exec { 'mkdir_templates':
     command => "mkdir -p ${elasticsearch::confdir}/templates_import",
-    path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
-    cwd     => '/',
     creates => "${elasticsearch::confdir}/templates_import"
   }
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -53,7 +53,8 @@ define elasticsearch::plugin(
   require elasticsearch::params
 
   Exec {
-    path => [ '/bin', '/sbin', '/usr/bin', '/usr/sbin' ]
+    path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    cwd  => '/',
   }
 
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -49,7 +49,8 @@ define elasticsearch::template(
   require elasticsearch
 
   Exec {
-    path => [ '/bin', '/usr/bin', '/usr/local/bin' ]
+    path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    cwd  => '/',
   }
 
   # Build up the url
@@ -97,7 +98,6 @@ define elasticsearch::template(
     # First check if it exists of course
     exec { "delete_template ${name}":
       command => "curl -s -XDELETE ${es_url}",
-      path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
       onlyif  => "test $(curl -s '${es_url}?pretty=true' | wc -l) -gt 1",
       notify  => $exec_notify
     }
@@ -109,7 +109,6 @@ define elasticsearch::template(
   if $delete == false {
     exec { "insert_template ${name}":
       command     => "curl -s -XPUT ${es_url} -d @${elasticsearch::confdir}/templates_import/elasticsearch-template-${name}.json",
-      path        => [ '/bin', '/usr/bin', '/usr/local/bin' ],
       unless      => "test $(curl -s '${es_url}?pretty=true' | wc -l) -gt 1",
       refreshonly => true,
       tries       => 3,


### PR DESCRIPTION
This should fix Errors like:

```
Failed to apply catalog: Validation of
Exec[mkdir_templates] failed: 'mkdir -p /opt/elasticsearch/config/templates_import' is not qualified and no path
was specified. Please qualify the command or specify a path.
```

in a manner that is consistent across the code-base.
