### PR TITLE
set default case to default param value

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,8 +29,9 @@ class elasticsearch::config {
   $settings = $elasticsearch::config
 
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {
-    true  => Class['elasticsearch::service'],
-    false => undef,
+    false   => undef,
+    default => Class['elasticsearch::service'],
+
   }
 
   file { $elasticsearch::confdir:

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -32,8 +32,8 @@ class elasticsearch::package {
     if $elasticsearch::version == false {
 
       $package_ensure = $elasticsearch::autoupgrade ? {
-        true  => 'latest',
-        false => 'present',
+        true    => 'latest',
+        default => 'present',
       }
 
     }  else {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -57,8 +57,8 @@ define elasticsearch::plugin(
   }
 
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {
-    true  => Class['elasticsearch::service'],
-    false => undef,
+    false   => undef,
+    default => Class['elasticsearch::service'],
   }
 
   if ($module_dir != '') {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -31,8 +31,8 @@ class elasticsearch::service {
   include elasticsearch
 
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {
-    true  => Service['elasticsearch'],
-    false => undef,
+    false   => undef,
+    default => Service['elasticsearch'],
   }
 
   #### Service management

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -68,13 +68,13 @@ define elasticsearch::template(
   }
 
   $file_ensure = $delete ? {
-    true  => 'absent',
-    false => 'present'
+    true    => 'absent',
+    default => 'present'
   }
 
   $file_notify = $delete ? {
-    true  => undef,
-    false => Exec[ "insert_template ${name}" ]
+    true    => undef,
+    default => Exec[ "insert_template ${name}" ]
   }
 
   # place the template file
@@ -89,8 +89,8 @@ define elasticsearch::template(
 
     # Only notify the insert_template call when we do a replace.
     $exec_notify = $replace ? {
-      true  => Exec[ "insert_template ${name}" ],
-      false => undef
+      true    => Exec[ "insert_template ${name}" ],
+      default => undef
     }
 
     # Delete the existing template


### PR DESCRIPTION
I added a default case to all of the selectors using the default value of the parameter as the default value for the selector.  Catches weird things/typos by just defaulting them as if the parameter was unset.
