### PR TITLE
Fix a scope issue when looking up the config hash

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,8 +31,6 @@ class elasticsearch::config {
     cwd  => '/',
   }
 
-  $settings = $elasticsearch::config
-
   $notify_elasticsearch = $elasticsearch::restart_on_change ? {
     false   => undef,
     default => Class['elasticsearch::service'],

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -71,12 +71,12 @@
   # initial string
   @yml_string = "### MANAGED BY PUPPET ###\n"
 
-  if !@settings.empty?
+  if !scope.lookupvar('elasticsearch::config').empty?
 
     @yml_string += "---\n"
 
     ## Transform shorted keys into full write up
-    transformed_config = transform(@settings)
+    transformed_config = transform(scope.lookupvar('elasticsearch::config'))
 
     # Merge it back into a hash
     tmphash = { }


### PR DESCRIPTION
Without this fix, the configuration file is being overwritten on some Puppet
agent version (tested on 2.7.11). Using scope.lookupvar() is IMO clearer as
well.

Fixes #56
