### PR TITLE
Simplify management of init defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,7 @@ class elasticsearch(
   $elasticsearch_group = $elasticsearch::params::elasticsearch_group,
   $purge_confdir       = $elasticsearch::params::purge_confdir,
   $service_provider    = 'init',
-  $init_defaults       = $elasticsearch::params::init_defaults,
+  $init_defaults       = undef,
   $init_defaults_file  = undef,
   $init_template       = undef,
   $config              = {},

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,18 +55,6 @@ class elasticsearch::params {
 
   ## init service provider
 
-  # init defaults
-  $init_defaults = {
-    'ES_HOME'            => '/usr/share/elasticsearch',
-    'ES_USER'            => 'root',
-    'MAX_OPEN_FILES'     => '65535',
-    'LOG_DIR'            => '/var/log/elasticsearch',
-    'DATA_DIR'           => '/var/lib/elasticsearch',
-    'WORK_DIR'           => '/tmp/elasticsearch',
-    'CONF_DIR'           => '/etc/elasticsearch',
-    'CONF_FILE'          => '/etc/elasticsearch/elasticsearch.yml',
-    'RESTART_ON_UPGRADE' => false
-  }
   # configuration directory
   $confdir = '/etc/elasticsearch'
 


### PR DESCRIPTION
Remove the quite useless `$init_defaults` hash from
`elasticsearch::params` and set the class parameter
`$elasticsearch::init_defaults` to undef by default.

The values in `$elasticsearch::params::init_defaults` are hardcoded in
the init script anyway, no need to also set them in the defaults file.
Instead let the defaults file only contain parameters the user wants to
override. These are supplied via the class parameter
`$elasticsearch::init_defaults` and end up in the defaults file.

This obsoletes/fixes #63.
