### PR TITLE
allow creation of data directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,6 +67,15 @@ class elasticsearch::config {
       mode   => '0644'
     }
 
+    if ( $elasticsearch::datadir != undef ) {
+      file { $elasticsearch::datadir:
+        ensure  => 'directory',
+        owner   => $elasticsearch::elasticsearch_user,
+        group   => $elasticsearch::elasticsearch_group,
+        mode    => '0770',
+      }
+    }
+
   } elsif ( $elasticsearch::ensure == 'absent' ) {
 
     file { $elasticsearch::confdir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,7 @@ class elasticsearch(
   $init_template       = undef,
   $config              = {},
   $confdir             = $elasticsearch::params::confdir,
+  $datadir             = undef,
   $plugindir           = $elasticsearch::params::plugindir,
   $plugintool          = $elasticsearch::params::plugintool,
   $java_install        = false,

--- a/spec/classes/004_elasticsearch_init_config_spec.rb
+++ b/spec/classes/004_elasticsearch_init_config_spec.rb
@@ -15,7 +15,7 @@ describe 'elasticsearch', :type => 'class' do
 
       it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:content => "### MANAGED BY PUPPET ###\n") }
 
-    end  
+    end
 
     context "set a value" do
 
@@ -91,6 +91,21 @@ describe 'elasticsearch', :type => 'class' do
       } end
 
       it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:notify => "Class[Elasticsearch::Service]") }
+    end
+
+  end
+
+  context 'data directory' do
+    let(:facts) do {
+      :operatingsystem => 'CentOS'
+    } end
+
+    context 'should allow creating datadir' do
+      let(:params) do {
+        :datadir => '/foo'
+      } end
+
+      it { should contain_file('/foo').with(:ensure => 'directory') }
     end
 
   end


### PR DESCRIPTION
I have my data directory outside of the normal elasticsearch install.  The RPM for elasticsearch creates the user/group so the data directory needs to be created after the package is installed (to set directory perms), but before the service is started (so data dir exists).  Defaults are unchanged.
