### PR TITLE
upstart support for controlling ElasticSearch

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class elasticsearch(
   $configdir             = $elasticsearch::params::configdir,
   $purge_configdir       = $elasticsearch::params::purge_configdir,
   $service_provider      = 'init',
-  $init_defaults         = undef,
+  $init_defaults         = $elasticsearch::params::init_defaults,
   $init_defaults_file    = undef,
   $init_template         = undef,
   $config                = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,12 +137,20 @@ class elasticsearch::params {
       $service_providers  = [ 'init' ]
       $defaults_location  = '/etc/sysconfig'
     }
-    'Debian', 'Ubuntu': {
+    'Debian': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true
       $service_pattern    = $service_name
       $service_providers  = [ 'init' ]
+      $defaults_location  = '/etc/default'
+    }
+    'Ubuntu': {
+      $service_name       = 'elasticsearch'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = $service_name
+      $service_providers  = [ 'upstart', 'init' ]
       $defaults_location  = '/etc/default'
     }
     'Darwin': {

--- a/manifests/service/upstart.pp
+++ b/manifests/service/upstart.pp
@@ -1,0 +1,128 @@
+# == Define: elasticsearch::service::upstart
+#
+# This class exists to coordinate all service management related actions,
+# functionality and logical units in a central place.
+#
+# <b>Note:</b> "service" is the Puppet term and type for background processes
+# in general and is used in a platform-independent way. E.g. "service" means
+# "daemon" in relation to Unix-like systems.
+#
+#
+# === Parameters
+#
+# This class does not provide any parameters.
+#
+#
+# === Examples
+#
+# === Authors
+#
+# * Richard Pijnenburg <mailto:richard@ispavailability.com>
+#
+define elasticsearch::service::upstart{
+
+  #### Service management
+
+  # set params: in operation
+  if $elasticsearch::ensure == 'present' {
+
+    case $elasticsearch::status {
+      # make sure service is currently running, start it on boot
+      'enabled': {
+        $service_ensure = 'running'
+        $service_enable = true
+      }
+      # make sure service is currently stopped, do not start it on boot
+      'disabled': {
+        $service_ensure = 'stopped'
+        $service_enable = false
+      }
+      # make sure service is currently running, do not start it on boot
+      'running': {
+        $service_ensure = 'running'
+        $service_enable = false
+      }
+      # do not start service on boot, do not care whether currently running
+      # or not
+      'unmanaged': {
+        $service_ensure = undef
+        $service_enable = false
+      }
+      # unknown status
+      # note: don't forget to update the parameter check in init.pp if you
+      #       add a new or change an existing status.
+      default: {
+        fail("\"${elasticsearch::status}\" is an unknown service status value")
+      }
+    }
+
+  # set params: removal
+  } else {
+
+    # make sure the service is stopped and disabled (the removal itself will be
+    # done by package.pp)
+    $service_ensure = 'stopped'
+    $service_enable = false
+
+  }
+
+  $notify_service = $elasticsearch::restart_on_change ? {
+    true  => Service[$name],
+    false => undef,
+  }
+
+
+  if ( $elasticsearch::status != 'unmanaged' ) {
+
+    # defaults file content. Either from a hash or file
+    if ($elasticsearch::init_defaults_file != undef) {
+      file { "${elasticsearch::params::defaults_location}/${name}":
+        ensure  => $elasticsearch::ensure,
+        source  => $elasticsearch::init_defaults_file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        before  => Service[$name],
+        notify  => $notify_service
+      }
+
+    } elsif ($elasticsearch::init_defaults != undef and is_hash($elasticsearch::init_defaults) ) {
+
+      augeas { "defaults_${name}":
+        incl     => "${elasticsearch::params::defaults_location}/${name}",
+        lens     => 'Shellvars.lns',
+        changes  => template("${module_name}/etc/sysconfig/defaults.erb"),
+        before   => Service[$name],
+        notify   => $notify_service
+      }
+
+    }
+
+    # init file from template
+    if ($elasticsearch::init_template != undef) {
+
+      file { "/etc/init/${name}.conf":
+        ensure  => $elasticsearch::ensure,
+        content => template($elasticsearch::init_template),
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0664',
+        before  => Service[$name],
+        notify  => $notify_service
+      }
+
+    }
+
+  }
+
+  # action
+  service { $name:
+    ensure     => $service_ensure,
+    enable     => $service_enable,
+    name       => $elasticsearch::params::service_name,
+    hasstatus  => $elasticsearch::params::service_hasstatus,
+    hasrestart => $elasticsearch::params::service_hasrestart,
+    pattern    => $elasticsearch::params::service_pattern,
+  }
+
+}

--- a/templates/etc/init/elasticsearch.Ubuntu.erb
+++ b/templates/etc/init/elasticsearch.Ubuntu.erb
@@ -1,0 +1,35 @@
+# elasticsearch - ElasticSearch Server
+#
+# ElasticSearch: OpenSource distributed realtime search & analysis
+
+description "ElasticSearch: OpenSource distributed realtime search & analysis"
+
+# Run ElasticSearch as this user ID and group ID
+setuid <%= @elasticsearch_user  %>
+setgid <%= @elasticsearch_group %>
+
+<% if @init_defaults['MAX_OPEN_FILES'] %>
+limit nofile <%= (@init_defaults['MAX_OPEN_FILES'].to_s + ' ') * 2)
+<% end -%>
+<% if @init_defaults['MAX_LOCKED_MEMORY'] %>
+limit memlock <%= (@init_defaults['MAX_LOCKED_MEMORY'].to_s + ' ') * 2)
+<% end -%>
+
+pre-start script
+	# Prepare environment
+	mkdir -p "<%= @init_defaults['LOG_DIR'] %>" "<%= @init_defaults['DATA_DIR'] %>" "<%= @init_defaults['WORK_DIR'] %>"
+	chown <%= @elasticsearch_user %>:<%= @elasticsearch_group %> "<%= @init_defaults['LOG_DIR'] %>" "<%= init_defaults['DATA_DIR'] %>" "<%= @init_defaults['WORK_DIR] %>"
+end
+
+
+start script
+	# overwrite settings from default file
+	if [ -f "<%= @defaults_location -%>/<%= @name -%>" ]; then
+		. "<%= @defaults_location -%>/<%= @name -%>"
+	fi
+	DAEMON=<%= @init_defaults['DAEMON'] %>
+	DAEMON_OPTS="-Des.default.config=<%= @init_defaults['CONF_FILE'] %> -Des.default.path.home=<%= @init_defaults['ES_HOME'] %> -Des.default.path.logs=<%= @init_defaults['LOG_DIR'] %> -Des.default.path.data=<%= @init_defaults['DATA_DIR'] %> -Des.default.path.work=<%= @init_defaults['WORK_DIR'] %> -Des.default.path.conf=<%= @init_defaults['CONF_DIR'] %>"
+
+	exec $DAEMON -f $DAEMON_OPTS
+end
+


### PR DESCRIPTION
on Ubuntu, the default init daemon is upstart. We'd like to support it,
so here's a first attempt in that direction.

We're basing the general startup on Debian's sysV init script. By
extending the params to make sure the init_defaults already include
system-independent defaults, we can easily use those in our upstart
script.
By ensuring the defaults file contains "export" it enables us to
actually override variables in the upstart script.
