### PR TITLE
Fixes harmless error message in yum repo

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,11 +42,11 @@ class elasticsearch::repo {
     }
     'RedHat': {
       yumrepo { 'elasticsearch':
-        descr     =>  'elasticsearch repo',
-        baseurl   =>  "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/centos",
-        gpgcheck  =>  1,
-        gpgkey    =>  'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-        enabled   =>  1,
+        descr    => 'elasticsearch repo',
+        baseurl  => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/centos",
+        gpgcheck => 1,
+        gpgkey   => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+        enabled  => 1,
       }
     }
     default: {


### PR DESCRIPTION
Fixes spacing according to puppet lint standard. 

Fixes harmless error in yum repo.

The name is not specified in the yum repo that is created, results in the following error when using yum. 

```
yum repolist
Loaded plugins: fastestmirror, security
Repository 'elasticsearch' is missing name in configuration, using id
Loading mirror speeds from cached hostfile
 * epel: mirrors.kernel.org
```
