### PR TITLE
Dirty "ensure => 'reinstalled'" support for plugin upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,14 @@ class { 'elasticsearch':
 }
 ```
 
+### Upgrade/reinstall plugin
+
+elasticsearch::plugin{'mobz/elasticsearch-head':
+  module_dir => 'head',
+    ensure => 'reinstalled'
+}
+
+Remember to change `reinstalled` to `present` after, otherwise, the plugin will be reinstalled every time.
 
 ##Limitations
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -17,6 +17,7 @@
 # [*ensure*]
 #   Whether the plugin will be installed or removed.
 #   Set to 'absent' to ensure a plugin is not installed
+#   Set to 'reinstalled' to ensure a plugin is reinstalled (use when upgrading plugin)
 #   Value type is string
 #   Default value: present
 #   This variable is optional
@@ -101,6 +102,13 @@ define elasticsearch::plugin(
         returns  => $exec_rets,
         notify   => $notify_service,
         require  => File[$elasticsearch::plugindir]
+      }
+    }
+    'reinstalled': {
+      exec {"reinstall_plugin_${name}":
+        command => "${elasticsearch::plugintool} --remove ${module_dir} ; ${install_cmd}",
+        notify  => $notify_service,
+        require  => Class['elasticsearch::package'],
       }
     }
     default: {


### PR DESCRIPTION
This is pretty dirty as it __always__ removes plugin and installs new version. I could avoid this, but I didn't found a way to check the version of installed plugins using ES plugin tool.

It also changes behavior so `ensure => 'blah-blah'` does not remove plugin, only `ensure => absent` does.