### PR TITLE
Only install plugins if they are missing

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -45,7 +45,7 @@
 # * Dennis Konert <mailto:dkonert@gmail.com>
 #
 define elasticsearch::plugin(
-    $module_dir,
+    $module_dir  = ${name},
     $ensure      = 'present',
     $url         = ''
 ) {
@@ -83,7 +83,6 @@ define elasticsearch::plugin(
         returns  => $exec_rets,
         notify   => $notify_service,
         require  => Class['elasticsearch::package'],
-        onlyif   => "test -d ${elasticsearch::plugindir}/${module_dir}",
       }
     }
     default: {


### PR DESCRIPTION
Otherwise subsequent puppet runs will fail:

Notice: /Stage[main]/Logelask::Elasticsearch/Elasticsearch::Plugin[elasticsearch/marvel/latest]/Exec[install-plugin-elasticsearch/marvel/latest]/returns: -> Installing elasticsearch/marvel/latest...
Notice: /Stage[main]/Logelask::Elasticsearch/Elasticsearch::Plugin[elasticsearch/marvel/latest]/Exec[install-plugin-elasticsearch/marvel/latest]/returns: Failed to install elasticsearch/marvel/latest, reason: plugin directory /usr/share/elasticsearch/plugins/marvel already exists. To update the plugin, uninstall it first using -remove elasticsearch/marvel/latest command
Error: /usr/share/elasticsearch/bin/plugin -install elasticsearch/marvel/latest returned 74 instead of one of [0]
Error: /Stage[main]/Logelask::Elasticsearch/Elasticsearch::Plugin[elasticsearch/marvel/latest]/Exec[install-plugin-elasticsearch/marvel/latest]/returns: change from notrun to 0 failed: /usr/share/elasticsearch/bin/plugin -install elasticsearch/marvel/latest returned 74 instead of one of [0]
Notice: /Stage[main]/Elasticsearch::Service/Elasticsearch::Service::Init[elasticsearch]/Service[elasticsearch]: Dependency Exec[install-plugin-elasticsearch/marvel/latest] has failures: true
Warning: /Stage[main]/Elasticsearch::Service/Elasticsearch::Service::Init[elasticsearch]/Service[elasticsearch]: Skipping because of failed dependencies
Notice: /Stage[main]/Elasticsearch/Anchor[elasticsearch::end]: Dependency Exec[install-plugin-elasticsearch/marvel/latest] has failures: true
Warning: /Stage[main]/Elasticsearch/Anchor[elasticsearch::end]: Skipping because of failed dependencies
