### PR TITLE
Add support for Debian 6.0 Squeeze

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -30,7 +30,14 @@ class elasticsearch::java {
         $package = 'java-1.7.0-openjdk'
       }
       'Debian', 'Ubuntu': {
-        $package = 'openjdk-7-jre-headless'
+        case $::lsbdistcodename {
+          'squeeze': {
+            $package = 'openjdk-6-jre-headless'
+          }
+          default: {
+            $package = 'openjdk-7-jre-headless'
+          }
+        }
       }
       'OpenSuSE': {
         $package = 'java-1_6_0-openjdk'

--- a/spec/classes/012_elasticsearch_java_spec.rb
+++ b/spec/classes/012_elasticsearch_java_spec.rb
@@ -24,11 +24,26 @@ describe 'elasticsearch', :type => 'class' do
 
     end
 
+    context "On Debian OS (6.0 Squeeze)" do
+
+      let :facts do {
+        :operatingsystem => 'Debian',
+        :kernel => 'Linux',
+        :osfamily => 'Debian',
+        :lsbdistcodename => 'squeeze'
+
+      } end
+
+      it { should contain_class('elasticsearch::java').that_requires('Anchor[elasticsearch::begin]') }
+      it { should contain_class('elasticsearch::package').that_requires('Class[elasticsearch::java]') }
+      it { should contain_package('openjdk-6-jre-headless') }
+
+    end
     context "On Ubuntu OS" do
 
       let :facts do {
         :operatingsystem => 'Ubuntu',
-         :kernel => 'Linux',
+        :kernel => 'Linux',
         :osfamily => 'Debian'
 
       } end


### PR DESCRIPTION
Hi,

this adds support for Debian Squeeze by falling back on `openjdk-6-jre-headless`.

Cheers,
Jan
