### PR TITLE
Add single quotes to value. Fixes #105

### DIFF
--- a/spec/classes/001_elasticsearch_init_debian_spec.rb
+++ b/spec/classes/001_elasticsearch_init_debian_spec.rb
@@ -175,11 +175,11 @@ describe 'elasticsearch', :type => 'class' do
 
             let (:params) {
               default_params.merge({
-                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' }
+                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' }
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl => '/etc/default/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n") }
+            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl => '/etc/default/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n") }
 
           end
 
@@ -199,12 +199,12 @@ describe 'elasticsearch', :type => 'class' do
 
            let (:params) {
               default_params.merge({
-                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' },
+                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' },
                 :restart_on_change => false
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/default/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n").without_notify }
+            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/default/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n").without_notify }
 
           end 
 

--- a/spec/classes/002_elasticsearch_init_redhat_spec.rb
+++ b/spec/classes/002_elasticsearch_init_redhat_spec.rb
@@ -175,11 +175,11 @@ describe 'elasticsearch', :type => 'class' do
 
             let (:params) {
               default_params.merge({
-                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' }
+                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' }
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl  => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n") }
+            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl  => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n") }
 
           end
 
@@ -199,12 +199,12 @@ describe 'elasticsearch', :type => 'class' do
 
             let (:params) {
               default_params.merge({
-                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' },
+                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' },
                 :restart_on_change => false
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n").without_notify }
+            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n").without_notify }
 
           end
 

--- a/spec/classes/003_elasticsearch_init_opensuse_spec.rb
+++ b/spec/classes/003_elasticsearch_init_opensuse_spec.rb
@@ -175,11 +175,11 @@ describe 'elasticsearch', :type => 'class' do
 
             let (:params) {
               default_params.merge({
-                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' }
+                :init_defaults => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' }
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl  => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n") }
+            it { should contain_augeas('defaults_elasticsearch').with(:notify => 'Service[elasticsearch]', :incl  => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n") }
 
           end
 
@@ -199,12 +199,12 @@ describe 'elasticsearch', :type => 'class' do
 
             let (:params) {
               default_params.merge({
-                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root' },
+                :init_defaults     => { 'ES_USER' => 'root', 'ES_GROUP' => 'root', 'ES_JAVA_OPTS' => '"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled"' },
                 :restart_on_change => false
               })
             }
 
-            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP root\nset ES_USER root\n").without_notify }
+            it { should contain_augeas('defaults_elasticsearch').with(:incl => '/etc/sysconfig/elasticsearch', :changes => "set ES_GROUP 'root'\nset ES_JAVA_OPTS '\"-server -XX:+UseTLAB -XX:+CMSClassUnloadingEnabled\"'\nset ES_USER 'root'\n").without_notify }
 
           end
 

--- a/templates/etc/sysconfig/defaults.erb
+++ b/templates/etc/sysconfig/defaults.erb
@@ -1,3 +1,3 @@
 <% @init_defaults.sort.map do |key, value| -%>
-set <%= key %> <%= value %>
+set <%= key %> '<%= value %>'
 <% end -%>


### PR DESCRIPTION
Adding single quotes to this line allows users to pass a string with double quotes through to the defaults file. See #105 for more information. Fixes #105.
