### PR TITLE
Run plugin exec commands as elasticsearch_user.  Fixes #107

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -53,6 +53,7 @@ define elasticsearch::plugin(
   Exec {
     path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     cwd  => '/',
+    user => $elasticsearch::elasticsearch_user,
   }
 
   $notify_service = $elasticsearch::restart_on_change ? {
@@ -82,7 +83,6 @@ define elasticsearch::plugin(
         creates  => "${elasticsearch::plugindir}/${module_dir}",
         returns  => $exec_rets,
         notify   => $notify_service,
-        user     => $elasticsearch::elasticsearch_user,
         require  => Class['elasticsearch::package']
       }
     }
@@ -91,7 +91,6 @@ define elasticsearch::plugin(
         command => "${elasticsearch::plugintool} --remove ${module_dir}",
         onlyif  => "test -d ${elasticsearch::plugindir}/${module_dir}",
         notify  => $notify_service,
-        user    => $elasticsearch::elasticsearch_user,
       }
     }
   }


### PR DESCRIPTION
Install all plugins as the specified ES user.  Otherwise, ES cannot load the plugins and will fail init.  See #107 for details.
