### PR TITLE
Ensure that the right owner is set on the plugindir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -95,6 +95,8 @@ class elasticsearch::config {
 
     file { $elasticsearch::params::plugindir:
       ensure => 'directory',
+      owner   => $elasticsearch::elasticsearch_user,
+      group   => $elasticsearch::elasticsearch_group,
       mode   => '0644'
     }
 


### PR DESCRIPTION
This should help issues like this one (https://gist.github.com/rtyler/10433041) where a plugin cannot be installed due to ownership issues on the plugindir
