### PR TITLE
Add support for SLC

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -110,7 +110,7 @@ class elasticsearch::params {
 
   # packages
   case $::operatingsystem {
-    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux': {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {
       # main application
       $package = [ 'elasticsearch' ]
     }
@@ -129,7 +129,7 @@ class elasticsearch::params {
 
   # service parameters
   case $::operatingsystem {
-    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux': {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true


### PR DESCRIPTION
Hi,

This is a trivial change that adds support for Scientific Linux CERN (SLC): http://linux.web.cern.ch/linux/scientific.shtml

Cheers,
Benjamin
