### PR TITLE
Fix undefined plugindir file resource, poor variable sourcing

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,7 +93,7 @@ class elasticsearch::config {
       notify  => $notify_service
     }
 
-    file { $elasticsearch::params::plugindir:
+    file { $elasticsearch::plugindir:
       ensure => 'directory',
       mode   => '0644'
     }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -80,14 +80,6 @@ define elasticsearch::plugin(
 
   case $ensure {
     'installed', 'present': {
-      unless defined (File[$elasticsearch::plugindir]) {
-        file { $elasticsearch::plugindir:
-          ensure => directory,
-          mode   => '0644',
-          owner  => $elasticsearch::elasticsearch_user,
-          group  => $elasticsearch::elasticsearch_group,
-        }
-      }
       exec {"install_plugin_${name}":
         command  => $install_cmd,
         creates  => "${elasticsearch::plugindir}/${module_dir}",


### PR DESCRIPTION
The elasticsearch::plugin resource completely fails to work in the current version of puppet. This is due to the fact that it is accessing variables outside it's scope, thus making the install_plugin exec require File[undef]. This change causes the plugin resource to include elasticsearch, allowing it to access the required plugindir variable. It then ensures that File[$elasticsearch::plugindir] is actually defined and defines that resource as the required metaparameter for the exec. 
