### PR TITLE
Improve datadir fuctionality

### DIFF
--- a/spec/classes/011_elasticsearch_init_config_spec.rb
+++ b/spec/classes/011_elasticsearch_init_config_spec.rb
@@ -114,6 +114,19 @@ describe 'elasticsearch', :type => 'class' do
       } end
 
       it { should contain_file('/foo').with(:ensure => 'directory') }
+      it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:content => "### MANAGED BY PUPPET ###\n---\npath: \n  data: /foo\n") }
+    end
+
+    context 'should allow creating multiple datadirs' do
+      let(:params) do {
+        :config  => { },
+        :datadir => ['/foo', '/foo2', '/foo3']
+      } end
+
+      it { should contain_file('/foo').with(:ensure => 'directory') }
+      it { should contain_file('/foo2').with(:ensure => 'directory') }
+      it { should contain_file('/foo3').with(:ensure => 'directory') }
+      it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:content => "### MANAGED BY PUPPET ###\n---\npath: \n  data: \n      - /foo\n      - /foo2\n      - /foo3\n") }
     end
 
   end

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -71,12 +71,12 @@
   # initial string
   @yml_string = "### MANAGED BY PUPPET ###\n"
 
-  if !scope.lookupvar('elasticsearch::config').empty?
+  if !scope.lookupvar('elasticsearch::config::config').empty?
 
     @yml_string += "---\n"
 
     ## Transform shorted keys into full write up
-    transformed_config = transform(scope.lookupvar('elasticsearch::config'))
+    transformed_config = transform(scope.lookupvar('elasticsearch::config::config'))
 
     # Merge it back into a hash
     tmphash = { }


### PR DESCRIPTION
Initally when the datadir option is set it would only create the data dir but not set it in the config.
This improvement will allow it to be created ( a single dir or an array of dirs ) and also set this in the config file
