### PR TITLE
Change behaviour of template management and clean up curl return code

### DIFF
--- a/spec/defines/003_elasticsearch_template_spec.rb
+++ b/spec/defines/003_elasticsearch_template_spec.rb
@@ -19,8 +19,8 @@ describe 'elasticsearch::template', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__template('foo') }
-    it { should contain_file('/etc/elasticsearch/templates_import/elasticsearch-template-foo.json').with(:source => 'puppet:///path/to/foo.json', :notify => "Exec[delete_template_foo]", :require => "Exec[mkdir_templates_elasticsearch]") }
-    it { should contain_exec('insert_template_foo').with(:command => "curl -sL -w \"%{http_code}\\n\" -XPUT http://localhost:9200/_template/foo -d @/etc/elasticsearch/templates_import/elasticsearch-template-foo.json -o /dev/null | egrep \"(200|201)\" > /dev/null", :unless => 'test $(curl -s \'http://localhost:9200/_template/foo?pretty=true\' | wc -l) -gt 1') }
+    it { should contain_file('/etc/elasticsearch/templates_import/elasticsearch-template-foo.json').with(:source => 'puppet:///path/to/foo.json', :notify => "Exec[insert_template_foo]", :require => "Exec[mkdir_templates_elasticsearch]") }
+    it { should contain_exec('insert_template_foo').with(:command => "curl -sL -XPUT http://localhost:9200/_template/foo -d @/etc/elasticsearch/templates_import/elasticsearch-template-foo.json -o /dev/null -f", :unless => 'curl -s http://localhost:9200/_template/foo -f') }
   end
 
   context "Delete a template" do
@@ -32,7 +32,7 @@ describe 'elasticsearch::template', :type => 'define' do
     it { should contain_elasticsearch__template('foo') }
     it { should_not contain_file('/etc/elasticsearch/templates_import/elasticsearch-template-foo.json').with(:source => 'puppet:///path/to/foo.json') }
     it { should_not contain_exec('insert_template_foo') }
-    it { should contain_exec('delete_template_foo').with(:command => 'curl -s -XDELETE http://localhost:9200/_template/foo', :notify => nil, :onlyif => 'test $(curl -s \'http://localhost:9200/_template/foo?pretty=true\' | wc -l) -gt 1' ) }
+    it { should contain_exec('delete_template_foo').with(:command => 'curl -s -XDELETE http://localhost:9200/_template/foo -f', :onlyif => 'curl -s -XGET http://localhost:9200/_template/foo -f' ) }
   end
 
   context "Add template with alternative host and port" do
@@ -45,7 +45,7 @@ describe 'elasticsearch::template', :type => 'define' do
 
     it { should contain_elasticsearch__template('foo') }
     it { should contain_file('/etc/elasticsearch/templates_import/elasticsearch-template-foo.json').with(:source => 'puppet:///path/to/foo.json') }
-    it { should contain_exec('insert_template_foo').with(:command => "curl -sL -w \"%{http_code}\\n\" -XPUT http://otherhost:9201/_template/foo -d @/etc/elasticsearch/templates_import/elasticsearch-template-foo.json -o /dev/null | egrep \"(200|201)\" > /dev/null", :unless => 'test $(curl -s \'http://otherhost:9201/_template/foo?pretty=true\' | wc -l) -gt 1') }
+    it { should contain_exec('insert_template_foo').with(:command => "curl -sL -XPUT http://otherhost:9201/_template/foo -d @/etc/elasticsearch/templates_import/elasticsearch-template-foo.json -o /dev/null -f", :unless => 'curl -s http://otherhost:9201/_template/foo -f') }
   end
 
 end


### PR DESCRIPTION
We can use PUT instead of DELETE+PUT/POST
Makes code easier to read and IMHO more robust

Also use `curl -f` to catch return codes matching HTTP codes

ensure => present: simply PUT the template
ensure => absent:  simply DELETE the template
