### PR TITLE
Improve README/Instances section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class { 'elasticsearch':
 
 ###Instances
 
-This module works with the concept of instances.
+This module works with the concept of instances. For service to start you need to specify at least one instance.
 
 ####Quick setup
 ```puppet


### PR DESCRIPTION
Make sure README undoubtably states that at least one instance
needs to be defined in order for service to start.
