### PR TITLE
[TESTING] make strict variable checking optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |c|
-  Puppet.settings[:strict_variables]=true
+  Puppet.settings[:strict_variables]=true if ENV['STRICT_VARIABLES'] == 'true'
   Puppet.settings[:ordering]='random'
   c.parser = 'future' if ENV['FUTURE_PARSER'] == 'true'
 end


### PR DESCRIPTION
Strict variable checking is only available in puppet 3.5 and up
