### PR TITLE
add support for LinuxMint operating system

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -29,7 +29,7 @@ class elasticsearch::java {
       'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon', 'OracleLinux': {
         $package = 'java-1.7.0-openjdk'
       }
-      'Debian', 'Ubuntu': {
+      'Debian', 'Ubuntu', 'LinuxMint': {
         case $::lsbdistcodename {
           'squeeze': {
             $package = 'openjdk-6-jre-headless'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,7 +115,7 @@ class elasticsearch::params {
       # main application
       $package = [ 'elasticsearch' ]
     }
-    'Debian', 'Ubuntu': {
+    'Debian', 'Ubuntu', 'LinuxMint': {
       # main application
       $package = [ 'elasticsearch' ]
     }
@@ -139,7 +139,7 @@ class elasticsearch::params {
       $defaults_location  = '/etc/sysconfig'
       $init_template      = 'elasticsearch.RedHat.erb'
     }
-    'Debian', 'Ubuntu': {
+    'Debian', 'Ubuntu', 'LinuxMint': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true

--- a/metadata.json
+++ b/metadata.json
@@ -62,6 +62,14 @@
       ]
     },
     {
+      "operatingsystem": "LinuxMint",
+      "operatingsystemrelease": [
+        "15",
+        "16",
+        "17"
+      ]
+    },
+    {
       "operatingsystem": "OpenSuSE",
       "operatingsystemrelease": [
         "12.x",

--- a/spec/classes/001_elasticsearch_init_debian_spec.rb
+++ b/spec/classes/001_elasticsearch_init_debian_spec.rb
@@ -6,7 +6,7 @@ describe 'elasticsearch', :type => 'class' do
     :config  => { 'node.name' => 'foo' }
   }
 
-  [ 'Debian', 'Ubuntu'].each do |distro|
+  [ 'Debian', 'Ubuntu', 'LinuxMint'].each do |distro|
 
     context "on #{distro} OS" do
 

--- a/spec/classes/012_elasticsearch_java_spec.rb
+++ b/spec/classes/012_elasticsearch_java_spec.rb
@@ -54,6 +54,21 @@ describe 'elasticsearch', :type => 'class' do
 
     end
 
+    context "On LinuxMint OS" do
+
+      let :facts do {
+        :operatingsystem => 'LinuxMint',
+        :kernel => 'Linux',
+        :osfamily => 'Debian'
+
+      } end
+
+      it { should contain_class('elasticsearch::java') }
+      it { should contain_class('elasticsearch::package').that_requires('Class[elasticsearch::java]') }
+      it { should contain_package('openjdk-7-jre-headless') }
+
+    end
+
     context "On CentOS OS " do
 
       let :facts do {


### PR DESCRIPTION
Since [facter 2.1.0](https://docs.puppetlabs.com/facter/2.1/release_notes.html), [LinuxMint is now supported](https://docs.puppetlabs.com/facter/2.1/release_notes.html#improvements-to-operating-system-detection) by the `operatingsystem` and `osfamily` facts. Thus the os detection stuff needs to be updated.