### PR TITLE
Fix dependency related CI breakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/fixtures/modules
 .ruby-version
 pkg/
 spec/reports/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ rvm:
 before_install: rm .gemfiles/Gemfile.rspec.lock || true
 gemfile: .gemfiles/Gemfile.rspec
 script:
- - "bundle exec rake lint"
- - "bundle exec rake syntax"
- - "bundle exec rake spec SPEC_OPTS='--format documentation --order random'"
+  - "bundle --without system_tests"
+  - "bundle exec rake lint"
+  - "bundle exec rake syntax"
+  - "bundle exec rake spec SPEC_OPTS='--format documentation --order random'"
 env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+##0.9.1 ( Feb 23, 2015 )
+
+###Summary
+This is the first bug fix release for 0.9 version.
+A bug was reported with the recursive file management.
+
+####Features
+None
+
+####Bugfixes
+* Fix recursive file management
+* Set undefined variables to work with strict_variables
+
+####Changes
+None
+
+####Testing changes
+None
+
+####Known bugs
+* Possible package conflicts when using ruby/python defines with main package name
+
 ##0.9.0 ( Feb 02, 2015 )
 
 ###Summary

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,34 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV['PUPPET_VERSION']
+gem 'ci_reporter_rspec'
+gem 'metadata-json-lint', :git => 'https://github.com/nibalizer/metadata-json-lint.git'
+gem 'puppet', puppetversion, :require => false
+gem 'puppet-lint'
+gem 'puppet-syntax'
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'rspec', '~> 3.1'
+gem 'rspec-puppet', :git => 'https://github.com/electrical/rspec-puppet.git', :branch => 'rspec3'
+gem 'rspec-puppet-facts'
+gem 'rspec_junit_formatter'
+gem 'webmock'
+
+case RUBY_VERSION
+when '1.8.7'
+  gem 'rake', '~> 10.1.0'
+else
+  gem 'rake'
+end
+
+group :system_test do
+  gem 'beaker', :git => 'https://github.com/electrical/beaker.git', :branch => 'hiera_config'
+  gem 'beaker-rspec', :git => 'https://github.com/puppetlabs/beaker-rspec.git', :branch => 'master'
+  gem 'docker-api', '~> 1.0'
+  gem 'pry'
+  gem 'rubysl-securerandom'
+end
+
+group :doc_file do
+  gem 'puppet-doc-lint'
+  gem 'rspec_junit_formatter'
+end

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'elasticsearch-elasticsearch'
-version '0.9.0'
+version '0.9.1'
 source 'https://github.com/elasticsearch/puppet-elasticsearch'
 author 'elasticsearch'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ elasticsearch::python { 'rawes': }
 elasticsearch::ruby { 'elasticsearch': }
 ```
 
+###Connection Validator
+
+This module offers a way to make sure an instance has been started and is up and running before
+doing a next action. This is done via the use of the `es_instance_conn_validator` resource.
+```puppet
+es_instance_conn_validator { 'myinstance' :
+  server => 'es.example.com',
+  port   => '9200',
+}
+```
+
+A common use would be for example :
+
+```puppet
+class { 'kibana4' :
+  require => Es_Instance_Conn_Validator['myinstance'],
+}
+```
+
 ###Package installation
 
 There are 2 different ways of installing the software

--- a/lib/puppet/provider/es_instance_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/es_instance_conn_validator/tcp_port.rb
@@ -1,0 +1,51 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/es_instance_validator'
+
+# This file contains a provider for the resource type `es_instance_conn_validator`,
+# which validates the Elasticsearch instance connection by attempting an https connection.
+
+Puppet::Type.type(:es_instance_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `es_instance_conn_validator`,
+        which validates the  connection by attempting an https
+        connection to the Elasticsearch instance." 
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for the Elasticsearch instance to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.debug("Failed to connect to the Elasticsearch instance; sleeping 2 seconds before retry")
+      sleep 2
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the ES instance in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to the ES instance within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to ES instance ! (#{@validator.instance_server}:#{@validator.instance_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::EsInstanceValidator.new(resource[:server], resource[:port])
+  end
+
+end

--- a/lib/puppet/type/es_instance_conn_validator.rb
+++ b/lib/puppet/type/es_instance_conn_validator.rb
@@ -1,0 +1,38 @@
+Puppet::Type.newtype(:es_instance_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+  and the Elasticsearch instance. It could potentially be used for other
+  purposes such as monitoring."
+  
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'DNS name or IP address of the server where Elasticsearch instance should be running.'
+    defaultto 'localhost'
+  end
+
+  newparam(:port) do
+    desc 'The port that the Elasticsearch instance should be listening on.'
+    defaultto 9200
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the Elasticsearch instance is not running; defaults to 60 seconds.'
+    defaultto 60
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet/util/es_instance_validator.rb
+++ b/lib/puppet/util/es_instance_validator.rb
@@ -1,0 +1,36 @@
+require 'socket'
+require 'timeout'
+
+module Puppet
+  module Util
+    class EsInstanceValidator
+      attr_reader :instance_server
+      attr_reader :instance_port
+
+      def initialize(instance_server, instance_port)
+        @instance_server = instance_server
+        @instance_port   = instance_port
+      end
+
+      # Utility method; attempts to make an https connection to the Elasticsearch instance.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@instance_server, @instance_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to Elasticsearch instance (#{@instance_server}:#{@instance_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -179,7 +179,7 @@ class elasticsearch::params {
       $service_providers  = 'systemd'
       $defaults_location  = '/etc/sysconfig'
       $init_template      = 'elasticsearch.systemd.erb'
-      $pid_dir            = '/var/run/elasticsearch/'
+      $pid_dir            = '/var/run/elasticsearch'
     }
     default: {
       fail("\"${module_name}\" provides no service parameters

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-elasticsearch",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "source": "https://github.com/elasticsearch/puppet-elasticsearch",
   "author": "elasticsearch",
   "license": "Apache-2.0",

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -46,6 +46,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_exec('mkdir_templates_elasticsearch').with(:command => 'mkdir -p /etc/elasticsearch/templates_import', :creates => '/etc/elasticsearch/templates_import') }
         it { should contain_file('/etc/elasticsearch/templates_import').with(:require => 'Exec[mkdir_templates_elasticsearch]') }
         it { should contain_file('/usr/share/elasticsearch') }
+        it { should contain_file('/usr/share/elasticsearch/lib') }
         it { should contain_file('/usr/share/elasticsearch/plugins') }
         it { should contain_file('/usr/share/elasticsearch/bin').with(:mode => '0755') }
 
@@ -251,8 +252,6 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/plugins').with(:owner => 'myesuser', :group => 'myesgroup') }
         it { should contain_file('/usr/share/elasticsearch/data').with(:owner => 'myesuser', :group => 'myesgroup') }
         it { should contain_file('/var/run/elasticsearch').with(:owner => 'myesuser') } if facts[:osfamily] == 'RedHat'
-        it { should contain_file('/var/run/elasticsearch').with(:owner => 'myesuser') } if facts[:osfamily] == 'RedHat'
-
       end
 
     end

--- a/spec/classes/001_hiera_spec.rb
+++ b/spec/classes/001_hiera_spec.rb
@@ -36,7 +36,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/etc/elasticsearch/es-01').with(:ensure => 'directory') }
         it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml') }
         it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
-        it { should contain_exec('mkdir_datadir_elasticsearch_es-01') }
+        it { should contain_exec('mkdir_datadir_elasticsearch_es-01').with(:command => 'mkdir -p /usr/share/elasticsearch/data/es-01') }
         it { should contain_file('/usr/share/elasticsearch/data/es-01') }
         it { should contain_file('/etc/init.d/elasticsearch-es-01') }
 
@@ -151,7 +151,7 @@ describe 'elasticsearch', :type => 'class' do
       it { should contain_file('/etc/elasticsearch/es-01').with(:ensure => 'directory') }
       it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml') }
       it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
-      it { should contain_exec('mkdir_datadir_elasticsearch_es-01') }
+      it { should contain_exec('mkdir_datadir_elasticsearch_es-01').with(:command => 'mkdir -p /usr/share/elasticsearch/data/es-01') }
       it { should contain_file('/usr/share/elasticsearch/data/es-01') }
       it { should contain_file('/etc/init.d/elasticsearch-es-01') }
 


### PR DESCRIPTION
This patch fixes unresolved specs errors caused by non-default Gemfile path:

```
+ rake spec
WARN: Unresolved specs during Gem::Specification.reset:
      rake (>= 0)
      puppet-lint (>= 0)
      puppet-syntax (>= 0)
      mocha (>= 0)
      rspec (~> 2.0)
      hiera (~> 1.0)
      json_pure (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
/home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:121:in `require': cannot load such file -- rspec-puppet-facts (LoadError)
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:121:in `require'
        from /home/bamboo/bamboo-home/xml-data/build-dir/2949122/PUP-PUPPETMODULEELASTICSEARCH-JOB1/spec/spec_helper.rb:2:in `<top (required)>'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/bamboo/bamboo-home/xml-data/build-dir/2949122/PUP-PUPPETMODULEELASTICSEARCH-JOB1/spec/classes/000_elasticsearch_init_spec.rb:1:in `<top (required)>'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/configuration.rb:1226:in `load'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/configuration.rb:1226:in `block in load_spec_files'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/configuration.rb:1224:in `each'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/configuration.rb:1224:in `load_spec_files'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:97:in `setup'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:85:in `run'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:70:in `run'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/lib/rspec/core/runner.rb:38:in `invoke'
        from /home/bamboo/.rvm/rubies/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.1/exe/rspec:4:in `<top (required)>'
        from /home/bamboo/.rvm/gems/ruby-2.1.3/bin/rspec:23:in `load'
        from /home/bamboo/.rvm/gems/ruby-2.1.3/bin/rspec:23:in `<main>'
rake aborted!
/home/bamboo/.rvm/rubies/ruby-2.1.3/bin/ruby -S rspec spec/classes/000_elasticsearch_init_spec.rb spec/classes/001_hiera_spec.rb spec/classes/005_elasticsearch_repo_spec.rb spec/classes/010_elasticsearch_init_unkown_spec.rb spec/classes/099_coverage_spec.rb spec/defines/001_elasticsearch_python_spec.rb spec/defines/002_elasticsearch_ruby_spec.rb spec/defines/003_elasticsearch_template_spec.rb spec/defines/004_elasticsearch_plugin_spec.rb spec/defines/005_elasticsearch_instance_spec.rb spec/defines/010_elasticsearch_service_init_spec.rb spec/defines/011_elasticsearch_service_system_spec.rb --color failed
/home/bamboo/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `eval'
/home/bamboo/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => spec_standalone
(See full trace by running task with --trace)
```

