### PR TITLE
Fixed so JAVA_HOME can be passed in through a init default.

### DIFF
--- a/templates/etc/init.d/elasticsearch.RedHat.erb
+++ b/templates/etc/init.d/elasticsearch.RedHat.erb
@@ -53,6 +53,7 @@ fi
 checkJava() {
     if [ -x "$JAVA_HOME/bin/java" ]; then
         JAVA="$JAVA_HOME/bin/java"
+        export JAVA_HOME
     else
         JAVA=`which java`
     fi


### PR DESCRIPTION
 Specifying JAVA_HOME in init defaults is not exported in init.d script #286