### PR TITLE
Initializing repo_version to false breaks parameter validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -214,7 +214,7 @@ class elasticsearch(
   $java_install          = false,
   $java_package          = undef,
   $manage_repo           = false,
-  $repo_version          = false,
+  $repo_version          = undef,
   $logging_file          = undef,
   $logging_config        = undef,
   $logging_template      = undef,


### PR DESCRIPTION
Looking at init.pp:282 it expects repo_version to be initialized to undef, not false:

    if $repo_version == undef {

This bug prevents puppet from displaying the intended error message:

Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: false is not a string.  It looks to be a FalseClass at
/etc/puppet/modules/elasticsearch/manifests/init.pp:285 on node my.server