### PR TITLE
Update apt key to full 40characters

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ class elasticsearch::repo {
         location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Latest version of puppetlabs/apt module shows warning on every puppet run if using a short key so this update includes the full 40 character key.