### PR TITLE
Set PATH from facter to resolve #286

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -256,7 +256,7 @@ define elasticsearch::instance(
       $global_init_defaults = { }
     }
 
-    $instance_init_defaults_main = { 'CONF_DIR' => $instance_configdir, 'CONF_FILE' => "${instance_configdir}/elasticsearch.yml", 'LOG_DIR' => "/var/log/elasticsearch/${name}", 'ES_HOME' => '/usr/share/elasticsearch' }
+    $instance_init_defaults_main = { 'CONF_DIR' => $instance_configdir, 'CONF_FILE' => "${instance_configdir}/elasticsearch.yml", 'LOG_DIR' => "/var/log/elasticsearch/${name}", 'ES_HOME' => '/usr/share/elasticsearch', 'PATH' => $::path }
 
     if (is_hash($init_defaults)) {
       $instance_init_defaults = $init_defaults


### PR DESCRIPTION
This will set the ```PATH``` in ```/etc/sysconfig/elasticsearch-instancename``` used for the System V init script ```elasticsearch-instancename``` to be what ```facter``` has. This is to mitigate the issue where running ```service elasticsearch-instancename``` does not recognize the system's PATH. As a more permanent fix you could source ```/etc/profile.d``` to better emulate the the user's environment.

Tested on: CentOS 6.6 x64