### PR TITLE
LimitNOFILE and LimitMEMLOCK in elasticsearch.systemd.erb

### DIFF
--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -151,6 +151,18 @@ define elasticsearch::service::systemd(
       $pid_dir           = $elasticsearch::pid_dir
       $defaults_location = $elasticsearch::defaults_location
 
+      if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_OPEN_FILES')) {
+        $nofile = $new_init_defaults['MAX_OPEN_FILES']
+      }else{
+        $nofile = '65535'
+      }
+
+      if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_LOCKED_MEMORY')) {
+        $memlock = $new_init_defaults['MAX_LOCKED_MEMORY']
+      }else{
+        $memlock = undef
+      }
+
       file { "/lib/systemd/system/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),

--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -10,9 +10,13 @@ Group=<%= @group %>
 PIDFile=<%= @pid_dir %>/elasticsearch-<%= @name %>.pid
 ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p <%= @pid_dir %>/elasticsearch-<%= @name %>.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
-LimitNOFILE=65535
+LimitNOFILE=<%= @nofile %>
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true
-#LimitMEMLOCK=infinity
+<% if @memlock == 'unlimited' %>
+LimitMEMLOCK=infinity
+<% else %>
+LimitMEMLOCK=<%= @memlock %>
+<% end %>
 # Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
 TimeoutStopSec=20
 


### PR DESCRIPTION
Hi,

With systemd, nofile and memlock limits are not configurable.
This Pull Request add support for custom LimitMEMLOCK and LimitNOFILE in elasticsearch.systemd.erb

Cheers
Romain