### PR TITLE
Provide a means to override apt-key key.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,9 @@
 #   Define plugins via a hash. This is mainly used with Hiera's auto binding
 #   Defaults to: undef
 #
+# [*apt_key*]
+#   Override GPG key for Apt, provided by this module.
+#
 # [*plugins_hiera_merge*]
 #   Enable Hiera's merging function for the plugins
 #   Defaults to: false
@@ -223,7 +226,8 @@ class elasticsearch(
   $instances             = undef,
   $instances_hiera_merge = false,
   $plugins               = undef,
-  $plugins_hiera_merge   = false
+  $plugins_hiera_merge   = false,
+  $apt_key               = $elasticsearch::params::apt_key
 ) inherits elasticsearch::params {
 
   anchor {'elasticsearch::begin': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,6 +120,7 @@ class elasticsearch::params {
     'Debian', 'Ubuntu': {
       # main application
       $package = [ 'elasticsearch' ]
+      $apt_key = 'D88E42B4'
     }
     'OpenSuSE': {
       $package = [ 'elasticsearch' ]

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ class elasticsearch::repo {
         location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => $elasticsearch::apt_key,
         key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Provide a means to override apt-key key.

Else you get:
Warning: /Apt_key[Add key: D88E42B4 from Apt::Source elasticsearch]: The id should be a full fingerprint (40 characters), see README.

Puppetlabs-apt ( >= v1.8.0)