### PR TITLE
Revert "Update apt key to full 40characters"

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ class elasticsearch::repo {
         location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+        key         => 'D88E42B4',
         key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Reverts elastic/puppet-elasticsearch#294

Due to some errors with some older Puppet Enterprise versions that ship older puppetlabs-apt versions its causing issues.
Since i don't want to break support for those we will have to revert back to the short key and just let puppetlabs-apt 1.8.0 moan about the short key as long as its not being rejected.