### PR TITLE
Use systemd to start service when on debian 8

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -107,7 +107,7 @@ class elasticsearch::config {
     file { '/etc/init.d/elasticsearch':
       ensure => 'absent',
     }
-    file { '/usr/lib/systemd/system/elasticsearch.service':
+    file { '/lib/systemd/system/elasticsearch.service':
       ensure => 'absent',
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,17 +159,15 @@ class elasticsearch::params {
       $service_pattern    = $service_name
       $defaults_location  = '/etc/default'
 
-      case $::operatingsystemmajrelease {
-        '8': {
-          $init_template     = 'elasticsearch.systemd.erb'
-          $service_providers = 'systemd'
-          $pid_dir           = '/var/run/elasticsearch'
-        }
-        default: {
-          $init_template     = 'elasticsearch.Debian.erb'
-          $service_providers = [ 'init' ]
-          $pid_dir           = false
-        }
+      if (($::operatingsystem == 'Debian' and $::operatingsystemmajrelease >= 8) or
+          ($::operatingsystem == 'Ubuntu' and $::operatingsystemmajrelease >= 15)) {
+        $init_template     = 'elasticsearch.systemd.erb'
+        $service_providers = 'systemd'
+        $pid_dir           = '/var/run/elasticsearch'
+      } else {
+        $init_template     = 'elasticsearch.Debian.erb'
+        $service_providers = [ 'init' ]
+        $pid_dir           = false
       }
     }
     'Darwin': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,6 +133,12 @@ class elasticsearch::params {
   # service parameters
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {
+      $service_name       = 'elasticsearch'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = $service_name
+      $defaults_location  = '/etc/sysconfig'
+      $pid_dir            = '/var/run/elasticsearch'
 
       case $::operatingsystemmajrelease {
         '7': {
@@ -145,22 +151,26 @@ class elasticsearch::params {
         }
       }
 
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $defaults_location  = '/etc/sysconfig'
-      $pid_dir            = '/var/run/elasticsearch'
     }
     'Debian', 'Ubuntu': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true
       $service_pattern    = $service_name
-      $service_providers  = 'init'
       $defaults_location  = '/etc/default'
-      $init_template      = 'elasticsearch.Debian.erb'
-      $pid_dir            = false
+
+      case $::operatingsystemmajrelease {
+        '8': {
+          $init_template     = 'elasticsearch.systemd.erb'
+          $service_providers = 'systemd'
+          $pid_dir           = '/var/run/elasticsearch'
+        }
+        default: {
+          $init_template     = 'elasticsearch.Debian.erb'
+          $service_providers = [ 'init' ]
+          $pid_dir           = false
+        }
+      }
     }
     'Darwin': {
       $service_name       = 'FIXME/TODO'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -152,15 +152,31 @@ class elasticsearch::params {
       }
 
     }
-    'Debian', 'Ubuntu': {
+    'Debian': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true
       $service_pattern    = $service_name
       $defaults_location  = '/etc/default'
 
-      if (($::operatingsystem == 'Debian' and $::operatingsystemmajrelease >= 8) or
-          ($::operatingsystem == 'Ubuntu' and $::operatingsystemmajrelease >= 15)) {
+      if ($::operatingsystemmajrelease >= 8) {
+        $init_template     = 'elasticsearch.systemd.erb'
+        $service_providers = 'systemd'
+        $pid_dir           = '/var/run/elasticsearch'
+      } else {
+        $init_template     = 'elasticsearch.Debian.erb'
+        $service_providers = [ 'init' ]
+        $pid_dir           = false
+      }
+    }
+    'Ubuntu': {
+      $service_name       = 'elasticsearch'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = $service_name
+      $defaults_location  = '/etc/default'
+
+      if ($::operatingsystemmajrelease >= 15) {
         $init_template     = 'elasticsearch.systemd.erb'
         $service_providers = 'systemd'
         $pid_dir           = '/var/run/elasticsearch'

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -146,10 +146,12 @@ define elasticsearch::service::systemd(
     # init file from template
     if ($init_template != undef) {
 
-      $user  = $elasticsearch::elasticsearch_user
-      $group = $elasticsearch::elasticsearch_group
+      $user              = $elasticsearch::elasticsearch_user
+      $group             = $elasticsearch::elasticsearch_group
+      $pid_dir           = $elasticsearch::pid_dir
+      $defaults_location = $elasticsearch::defaults_location
 
-      file { "/usr/lib/systemd/system/elasticsearch-${name}.service":
+      file { "/lib/systemd/system/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),
         before  => Service["elasticsearch-instance-${name}"],
@@ -162,7 +164,7 @@ define elasticsearch::service::systemd(
 
   } elsif($status != 'unmanaged') {
 
-    file { "/usr/lib/systemd/system/elasticsearch-${name}.service":
+    file { "/lib/systemd/system/elasticsearch-${name}.service":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"],

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -53,7 +53,7 @@ describe 'elasticsearch', :type => 'class' do
 
 	# file removal from package
 	it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
-	it { should contain_file('/usr/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
+	it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
 	it { should contain_file("#{defaults_path}/elasticsearch").with(:ensure => 'absent') }
 	it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
 	it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -45,7 +45,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
     it { should contain_elasticsearch__service__systemd('es-01') }
     it { should_not contain_service('elasticsearch-instance-es-01') }
-    it { should_not contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service') }
+    it { should_not contain_file('/lib/systemd/system/elasticsearch-es-01.service') }
     it { should_not contain_file('/etc/sysconfig/elasticsearch-es-01') }
 
   end
@@ -109,7 +109,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
       } end
 
-      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[elasticsearch-instance-es-01]') }
+      it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "No restart when 'restart_on_change' is false" do
@@ -121,7 +121,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
       } end
 
-      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+      it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
 
     end
 

--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -4,11 +4,11 @@ Documentation=http://www.elasticsearch.org
 
 [Service]
 Type=forking
-EnvironmentFile=/etc/sysconfig/elasticsearch-<%= @name %>
+EnvironmentFile=<%= @defaults_location %>/elasticsearch-<%= @name %>
 User=<%= @user %>
 Group=<%= @group %>
-PIDFile=/var/run/elasticsearch/elasticsearch-<%= @name %>.pid
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch-<%= @name %>.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+PIDFile=<%= @pid_dir %>/elasticsearch-<%= @name %>.pid
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p <%= @pid_dir %>/elasticsearch-<%= @name %>.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
 LimitNOFILE=65535
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true


### PR DESCRIPTION
I tested this on EL7, debian 7 and debian 8. No changes are made on the 2 former platforms.

A couple of things to keep in mind:
 * as discussed on IRC, adding the support for debian8 to the test suite is out of scope, so currently there is no test coverage for this.
 * if a previous version of the module is used to setup elasticsearch on a debian 8 machine, systemd's LSB wrapper will take care of the service *once systemctl daemon-reload* has been run (which this module doesn't do before this patch, so someting else has to trigger this command)
 * if upgrading from a previous version of this module, `/etc/init.d/elasticsearch-xyz` will be left behind (unmanaged & undeleted)