### PR TITLE
puppetlabs/apt 2.0.x compatibility

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -43,7 +43,7 @@ class elasticsearch::repo {
         key => {
           id         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
           source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-		}
+		},
         include_src => false,
       }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,7 +44,7 @@ class elasticsearch::repo {
           id         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
           source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
 		},
-        include_src => false,
+		include => { 'src' => false },
       }
     }
     'RedHat', 'Linux': {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,8 +40,10 @@ class elasticsearch::repo {
         location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+        key => {
+          id         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+		}
         include_src => false,
       }
     }


### PR DESCRIPTION
Hello,
Here is my version for puppetlabs/apt 2.0.x compatibility. I have tested on : 
Mac OS X 10.10.3 , vagrant 1.7.2, virtualbox 4.3.26, ubuntu 14.04, puppet 3.7.5 and librarian-puppet 2.1.0

Best
Zoltan