### PR TITLE
fix for puppetlabs-apt 2.0 

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -37,12 +37,18 @@ class elasticsearch::repo {
       }
 
       apt::source { 'elasticsearch':
-        location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
-        release     => 'stable',
-        repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-        include_src => false,
+        location => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
+        release  => 'stable',
+        repos    => 'main',
+        key      => {
+          id     => 'D88E42B4',
+          source => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+        },
+        include  => {
+          src => false
+        },
+      } -> exec { "apt-get update for elasticsearch":
+            command => '/usr/bin/apt-get update',
       }
     }
     'RedHat', 'Linux': {


### PR DESCRIPTION
Hello,

Just a small PR to support puppetlabs apt 2.0 changes + a exec apt-get update before package install.

This PR would break backward compatibility with older versions of puppetlabs-apt

Regards

M