### PR TITLE
Added support for puppetlabs-apt >= 2.0

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,9 +40,10 @@ class elasticsearch::repo {
         location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-        include_src => false,
+        key         => {
+          id     => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          source => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch'
+        }
       }
     }
     'RedHat', 'Linux': {

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/apt", 
+      "version_requirement": ">= 2.0.0 <3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is needed for puppetlabs-apt >= 2.0 support.