### PR TITLE
Change restart on config change to false

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class elasticsearch::params {
   $status = 'enabled'
 
   # restart on configuration change?
-  $restart_on_change = true
+  $restart_on_change = false
 
   # Purge configuration directory
   $purge_configdir = false


### PR DESCRIPTION
This is to make sure we don't restart ES after a config change and let
the user handle the restart.
We can override it via the main class.

closes #336