### PR TITLE
APT 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This module has been tested against ES 1.0 and up.
 #### Repository management
 When using the repository management you will need the following dependency modules:
 
-* Debian/Ubuntu: [Puppetlabs/apt](http://forge.puppetlabs.com/puppetlabs/apt) Version 1.8.x or lower.
+* Debian/Ubuntu: [Puppetlabs/apt](http://forge.puppetlabs.com/puppetlabs/apt)
 * OpenSuSE: [Darin/zypprepo](https://forge.puppetlabs.com/darin/zypprepo)
 
 ##Usage

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,13 +36,27 @@ class elasticsearch::repo {
         class { 'apt': }
       }
 
-      apt::source { 'elasticsearch':
-        location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
-        release     => 'stable',
-        repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-        include_src => false,
+      if defined('apt::setting') {
+        # apt >= 2.0
+        apt::source { 'elasticsearch':
+          location => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
+          release  => 'stable',
+          repos    => 'main',
+          key      => {
+            id     => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+            source => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+          },
+        }
+      } else {
+        # apt < 2
+        apt::source { 'elasticsearch':
+          location    => "http://packages.elasticsearch.org/elasticsearch/${elasticsearch::repo_version}/debian",
+          release     => 'stable',
+          repos       => 'main',
+          key         => 'D88E42B4',
+          key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+          include_src => false,
+        }
       }
     }
     'RedHat', 'Linux': {


### PR DESCRIPTION
Adds support for puppetlabs-apt 2.0

`bundle exec rake spec` and `bundle exec rake lint` finished without errors.

I couldn't run beaker tests:
```
Beaker::Hypervisor, found some docker boxes to create
Provisioning docker
provisioning ubuntu-14-04
Using docker server at 192.168.59.103
Warning: Try 1 -- Host 192.168.59.103 unreachable: Errno::ECONNREFUSED - Connection refused - connect(2) for "192.168.59.103" port 32774
```