### PR TITLE
use init service provider for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -132,7 +132,7 @@ class elasticsearch::params {
 
   # service parameters
   case $::operatingsystem {
-    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC': {
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
       $service_hasstatus  = true
@@ -148,6 +148,16 @@ class elasticsearch::params {
         $service_providers = 'init'
       }
 
+    }
+    'Amazon': {
+      $service_name       = 'elasticsearch'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = $service_name
+      $defaults_location  = '/etc/sysconfig'
+      $pid_dir            = '/var/run/elasticsearch'
+      $init_template      = 'elasticsearch.RedHat.erb'
+      $service_providers  = 'init'
     }
     'Debian': {
       $service_name       = 'elasticsearch'


### PR DESCRIPTION
release 0.9.6 breaks (https://github.com/elastic/puppet-elasticsearch/commit/066f70c99d7010ec9ddfe07ec87f4671765c68c4) service management on Amazon Linux since it does not have systemd installed
this change creates separate case for Amazon Linux to allow to define "init" as service provider

facter output from AWS linux

```
# facter  operatingsystem
Amazon
# facter  operatingsystemmajrelease
2015
```

Change-Id: I943eab5a21ece2e05d1cae185caaea1974adaabe