### PR TITLE
Fix systemd template

### DIFF
--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -14,7 +14,7 @@ LimitNOFILE=<%= @nofile %>
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true
 <% if @memlock == 'unlimited' %>
 LimitMEMLOCK=infinity
-<% else %>
+<% elsif @memlock %>
 LimitMEMLOCK=<%= @memlock %>
 <% end %>
 # Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)


### PR DESCRIPTION
When MAX_LOCKED_MEMORY was not set it would leave an empty setting in
the systemd file which caused some errors.
Now we check if its actually set ( not undef ) before printing its
value.

Closes #362