### PR TITLE
Improve package version handling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,6 +292,21 @@ class elasticsearch(
     }
   }
 
+  if ($version != false) {
+    case $::osfamily {
+      'RedHat', 'Linux', 'Suse': {
+        if ($version =~ /.+-\d/) {
+          $real_version = $version
+        } else {
+          $real_version = "${version}-1"
+        }
+      }
+      default: {
+        $real_version = $version
+      }
+    }
+  }
+
   #### Manage actions
 
   # package(s)

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -47,7 +47,7 @@ class elasticsearch::package {
     } else {
 
       # install specific version
-      $package_ensure = $elasticsearch::version
+      $package_ensure = $elasticsearch::real_version
 
     }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -87,13 +87,13 @@ class elasticsearch::repo {
         apt::pin { $elasticsearch::package_name:
           ensure   => 'present',
           packages => $elasticsearch::package_name,
-          version  => $elasticsearch::version,
+          version  => $elasticsearch::real_version,
           priority => 1000,
         }
       }
       'RedHat', 'Linux': {
 
-        yum::versionlock { "0:elasticsearch-${elasticsearch::version}.noarch":
+        yum::versionlock { "0:elasticsearch-${elasticsearch::real_version}.noarch":
           ensure => 'present',
         }
       }

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -15,14 +15,17 @@ describe 'elasticsearch', :type => 'class' do
         let(:defaults_path) { '/etc/default' }
         let(:pkg_ext) { 'deb' }
         let(:pkg_prov) { 'dpkg' }
+        let(:version_add) { '' }
       when 'RedHat'
         let(:defaults_path) { '/etc/sysconfig' }
         let(:pkg_ext) { 'rpm' }
         let(:pkg_prov) { 'rpm' }
+        let(:version_add) { '-1' }
       when 'Suse'
         let(:defaults_path) { '/etc/sysconfig' }
         let(:pkg_ext) { 'rpm' }
         let(:pkg_prov) { 'rpm' }
+        let(:version_add) { '-1' }
       end
 
       let(:facts) do
@@ -80,7 +83,20 @@ describe 'elasticsearch', :type => 'class' do
               })
             }
 
-            it { should contain_package('elasticsearch').with(:ensure => '1.0') }
+            it { should contain_package('elasticsearch').with(:ensure => "1.0#{version_add}") }
+          end
+
+          if facts[:osfamily] == 'RedHat'
+            context 'Handle special CentOS/RHEL package versioning' do
+
+              let (:params) {
+                default_params.merge({
+                  :version => '1.1-2'
+                })
+              }
+
+              it { should contain_package('elasticsearch').with(:ensure => "1.1-2") }
+            end
           end
 
           context 'with specified package name' do

--- a/spec/spec_acceptance_common.rb
+++ b/spec/spec_acceptance_common.rb
@@ -15,9 +15,9 @@
       test_settings['defaults_file_b'] = '/etc/sysconfig/elasticsearch-es-02'
       test_settings['port_a']          = '9200'
       test_settings['port_b']          = '9201'
-      test_settings['install_package_version'] = '1.3.5-1'
+      test_settings['install_package_version'] = '1.3.5'
       test_settings['install_version'] = '1.3.5'
-      test_settings['upgrade_package_version'] = '1.3.6-1'
+      test_settings['upgrade_package_version'] = '1.3.6'
       test_settings['upgrade_version'] = '1.3.6'
     when 'Debian'
       case fact('operatingsystem')


### PR DESCRIPTION
RH family distro's require the package version to contain the release
version as well while others dont.
This makes it very confusing and not easy to maintain cross distro.

Added a small logic that adds the release version if its not in the
original version option.

Closes #364