### PR TITLE
Dont fail if we can't pin the package

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -98,7 +98,7 @@ class elasticsearch::repo {
         }
       }
       default: {
-        fail("Unable to pin package for OSfamily \"${::osfamily}\"")
+        warning("Unable to pin package for OSfamily \"${::osfamily}\".")
       }
     }
   }


### PR DESCRIPTION
Some distros dont support package pinning or dont have support for it
yet. Make sure we print out a warning instead of failing the run.