### PR TITLE
Restart Elasticsearch only when cluster status is green, 

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -146,7 +146,7 @@ define elasticsearch::plugin(
       exec {"install_plugin_${name}":
         command => $install_cmd,
         creates => "${elasticsearch::plugindir}/${plugin_dir}",
-        onlyif  => "curl -s -XGET 'http://${::ipaddress}:${es_port}/_cluster/health?pretty=true' | awk -F: '/status/{gsub(\"\\\"\",\"\");gsub(\",\",\"\");gsub(\" \",\"\");print \$2}' | grep -q -w green",
+        onlyif  => "curl -s -XGET 'http://${es_interface}:${es_port}/_cluster/health?pretty=true' | awk -F: '/status/{gsub(\"\\\"\",\"\");gsub(\",\",\"\");gsub(\" \",\"\");print \$2}' | grep -q -w green",
         returns => $exec_rets,
         notify  => $notify_service,
         require => File[$elasticsearch::plugindir],

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -43,6 +43,16 @@
 #   Specify all the instances related
 #   value type is string or array
 #
+# [*es_port*]
+#   Specify the port that elasticsearch is listening on
+#   value type is string
+#   Default value: 9200
+#
+# [*es_interface*]
+#   Specify the interface that elasticsearch is listening on
+#   value type is string
+#   Default value: localhost
+#
 # === Examples
 #
 # # From official repository
@@ -67,6 +77,8 @@ define elasticsearch::plugin(
     $url         = undef,
     $proxy_host  = undef,
     $proxy_port  = undef,
+    $es_port     = '9200',
+    $es_interface= 'localhost',
 ) {
 
   include elasticsearch
@@ -97,14 +109,14 @@ define elasticsearch::plugin(
 
   # set proxy by override or parse and use proxy_url from
   # elasticsearch::proxy_url or use no proxy at all
-  
+
   if ($proxy_host != undef and $proxy_port != undef) {
     $proxy = " -DproxyPort=${proxy_port} -DproxyHost=${proxy_host}"
   }
   elsif ($elasticsearch::proxy_url != undef) {
     $proxy_host_from_url = regsubst($elasticsearch::proxy_url, '(http|https)://([^:]+)(|:\d+).+', '\2')
     $proxy_port_from_url = regsubst($elasticsearch::proxy_url, '(http|https)://([^:]+)?(:(\d+)).+', '\4')
-    
+
     # validate parsed values before using them
     if (is_string($proxy_host_from_url) and is_integer($proxy_port_from_url)) {
       $proxy = " -DproxyPort=${proxy_port_from_url} -DproxyHost=${proxy_host_from_url}"
@@ -134,6 +146,7 @@ define elasticsearch::plugin(
       exec {"install_plugin_${name}":
         command => $install_cmd,
         creates => "${elasticsearch::plugindir}/${plugin_dir}",
+        onlyif  => "curl -s -XGET 'http://${::ipaddress}:${es_port}/_cluster/health?pretty=true' | awk -F: '/status/{gsub(\"\\\"\",\"\");gsub(\",\",\"\");gsub(\" \",\"\");print \$2}' | grep -q -w green",
         returns => $exec_rets,
         notify  => $notify_service,
         require => File[$elasticsearch::plugindir],


### PR DESCRIPTION
we have this working in production because we are using puppet for managing
elasticsearch, and on every plugin install we've had to do it
manually(which beats the purpose of puppet)in places where the cluster
has 2 or 3 nodes because  it can happen in some cases that puppet runs at the same
time and the whole cluster goes down since it takes time for one of them
to resync the data and while that is happening the other one restarts.
With this check puppet will wait until all data is synced and allocated properly ( cluster state green)
and then will apply the plugin, restarting the node.