### PR TITLE
make plugin_dir() handle short plugin names properly

### DIFF
--- a/lib/puppet/parser/functions/plugin_dir.rb
+++ b/lib/puppet/parser/functions/plugin_dir.rb
@@ -31,11 +31,10 @@ module Puppet::Parser::Functions
           endname = plugin
         end
       else
-        raise(Puppet::ParseError, "Unable to parse plugin name: #{plugin_name}")
+        endname = plugin_name
       end
 
-      return endname
-
+      endname
     end
   end
 end

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -89,11 +89,7 @@ define elasticsearch::plugin(
       warning("module_dir settings is deprecated for plugin ${name}. The directory is now auto detected.")
   }
 
-  if ($url == undef) {
-    $plugin_dir = plugin_dir($name)
-  } else {
-    $plugin_dir = $name
-  }
+  $plugin_dir = plugin_dir($name)
 
   # set proxy by override or parse and use proxy_url from
   # elasticsearch::proxy_url or use no proxy at all


### PR DESCRIPTION
if a short plugin name such as "marvel" is passed instead of a full plugin name, the first element
of the name is returned. This allows calling plugin_dir() on the short plugin name as well, so that
we can stick with the same naming conventions even when passing an url

as discussed on IRC.