### PR TITLE
Use full-length APT key fingerprint.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ class elasticsearch::repo {
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Prevents warning from Puppet:

  `The id should be a full fingerprint (40 characters)`