### PR TITLE
Export JAVA_HOME in the Redhat init script.

### DIFF
--- a/templates/etc/init.d/elasticsearch.RedHat.erb
+++ b/templates/etc/init.d/elasticsearch.RedHat.erb
@@ -42,6 +42,7 @@ export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_CLASSPATH
+export JAVA_HOME 
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
Fix a bug in the Redhat init script that's already been fixed upstream.

https://github.com/elastic/elasticsearch/issues/5433
