### PR TITLE
fix regex retrieving proxy port while downloading plugin

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -108,7 +108,7 @@ define elasticsearch::plugin(
   }
   elsif ($elasticsearch::proxy_url != undef) {
     $proxy_host_from_url = regsubst($elasticsearch::proxy_url, '(http|https)://([^:]+)(|:\d+).+', '\2')
-    $proxy_port_from_url = regsubst($elasticsearch::proxy_url, '(http|https)://([^:]+)?(:(\d+)).+', '\4')
+    $proxy_port_from_url = regsubst($elasticsearch::proxy_url, '(?:http|https)://[^:/]+(?::([0-9]+))?(?:/.*)?', '\1')
     
     # validate parsed values before using them
     if (is_string($proxy_host_from_url) and is_integer($proxy_port_from_url)) {


### PR DESCRIPTION
issue: if url is 'http://my_proxy.domain.tld:3128 your regexp will return "312" instead of "3128"