### PR TITLE
Require the config before starting the service

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -279,6 +279,7 @@ define elasticsearch::instance(
       mode    => '0644',
       notify  => $notify_service,
       require => Class['elasticsearch::package'],
+      before  => Elasticsearch::Service[$name],
     }
 
     $require_service = Class['elasticsearch::package']

--- a/spec/defines/005_elasticsearch_instance_spec.rb
+++ b/spec/defines/005_elasticsearch_instance_spec.rb
@@ -206,6 +206,8 @@ describe 'elasticsearch::instance', :type => 'define' do
         let(:pre_condition) { 'class {"elasticsearch": }'  }
 
           it { should contain_elasticsearch__service('es-01').with(:init_template => "elasticsearch/etc/init.d/elasticsearch.#{initscript}.erb", :init_defaults => {"CONF_DIR"=>"/etc/elasticsearch/es-01", "CONF_FILE"=>"/etc/elasticsearch/es-01/elasticsearch.yml", "LOG_DIR"=>"/var/log/elasticsearch/es-01", "ES_HOME"=>"/usr/share/elasticsearch"}) }
+          it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml').that_comes_before('Elasticsearch::Service[es-01]') }
+          it { should contain_file('/etc/elasticsearch/es-01/logging.yml').that_comes_before('Elasticsearch::Service[es-01]') }
 
       end
 


### PR DESCRIPTION
Hi,

This PR fixes an issue only seen with restart_on_change => true.
Due to the missing requires, Puppet sometimes tries to start the service before setting the config of the instance, resulting in a failure. This isn't seen in the default configuration because the notify wiil force the service to be delayed till after the (re)start.

Note that I am unable to run the test suite as the following command returns an error:
$ bundle install --path vendor/bundle
...
Gem::InstallError: i18n requires Ruby version >= 1.9.3.
An error occurred while installing i18n (0.7.0), and Bundler cannot continue.
Make sure that `gem install i18n -v '0.7.0'` succeeds before bundling.

Regards,
Steven