### PR TITLE
Honor the plugindir setting when installing plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -138,10 +138,10 @@ define elasticsearch::plugin(
   }
 
   if ($real_url == undef) {
-    $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name}"
+    $install_cmd = "${elasticsearch::plugintool}${proxy} install -Des.path.plugins=${elasticsearch::plugindir} ${name}"
     $exec_rets = [0,]
   } else {
-    $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name} --url ${real_url}"
+    $install_cmd = "${elasticsearch::plugintool}${proxy} install -Des.path.plugins=${elasticsearch::plugindir} ${name} --url ${real_url}"
     $exec_rets = [0,1]
   }
 
@@ -149,7 +149,7 @@ define elasticsearch::plugin(
     'installed', 'present': {
       $name_file_path = "${elasticsearch::plugindir}/${plugin_dir}/.name"
       exec {"purge_plugin_${plugin_dir}_old":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} --remove -Des.path.plugins=${elasticsearch::plugindir} ${plugin_dir}",
         onlyif  => "test -e ${elasticsearch::plugindir}/${plugin_dir} && test \"$(cat ${name_file_path})\" != '${name}'",
         before  => Exec["install_plugin_${name}"],
       }
@@ -168,7 +168,7 @@ define elasticsearch::plugin(
     }
     'absent': {
       exec {"remove_plugin_${name}":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} --remove -Des.path.plugins=${elasticsearch::plugindir} ${plugin_dir}",
         onlyif  => "test -d ${elasticsearch::plugindir}/${plugin_dir}",
         notify  => $notify_service,
       }


### PR DESCRIPTION
Hi,

This PR allows plugins to be installed in the proper directory.
When changing the plugindir, plugins keep getting installed into the default directory (/usr/share/elasticsearch/plugins)'. This causes a Puppet run to fail since the check for installed plugins *is* changed.

Use case:
The people initially setting up Elasticsearch at our site opted for a separate filesystem, mounted on '/es' with some subdirectories:
/es/bin (helperscripts)
/es/logs
/es/data
/es/plugins

Regards,
Steven

PS: no CLA required, this patch follows the existing license, which is Apache License, Version 2.0.

