### PR TITLE
Add require on apt::update for puppetlabs-apt 2.x

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -177,10 +177,17 @@ class elasticsearch::package {
 
   if ($elasticsearch::package_provider == 'package') {
 
+    if $elasticsearch::manage_repo {
+      $pkg_require = Class['apt::update']
+    } else {
+      $pkg_require = undef
+    }
+
     package { $elasticsearch::package_name:
       ensure   => $package_ensure,
       source   => $pkg_source,
       provider => $pkg_provider,
+      require  => $pkg_require,
     }
 
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.4.0 < 2.0.0"
+      "version_requirement": ">= 1.4.0 < 2.2.0"
     },
     {
       "name": "ceritsc/yum",


### PR DESCRIPTION
Since puppetlabs-apt 2.1.0, we have to trigger apt::update when adding a new source.

See : https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

This pull request intends to fix that.