### PR TITLE
Clean up apt block

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,7 @@ class elasticsearch::repo {
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+        key         => 'D88E42B4',
         key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
         include_src => false,
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -32,15 +32,14 @@ class elasticsearch::repo {
 
   case $::osfamily {
     'Debian': {
-      if !defined(Class['apt']) {
-        class { 'apt': }
-      }
+      include ::apt
+      Class['apt::update'] -> Package[$elasticsearch::package_name]
 
       apt::source { 'elasticsearch':
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Remove the conditional apt block (replacing it with simple `include ::apt`). Also explicitly state that `apt::update` should come before any packages are installed.