### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Please note that this does not work when you specify 'latest' as a version numbe
 ###Scripts
 
 Install [scripts](http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html) to be used by Elasticsearch.
-These scripts are shared accross all defined instances on the same host.
+These scripts are shared across all defined instances on the same host.
 
 ```puppet
 elasticsearch::script { 'myscript':


### PR DESCRIPTION
@elastic, I've corrected a typographical error in the documentation of the [puppet-elasticsearch](https://github.com/elastic/puppet-elasticsearch) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.