### PR TITLE
initial commit for shield. users and roles only

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -182,6 +182,11 @@
 #   package upgrades.
 #   Defaults to: true
 #
+# [*shield_users_merge*]
+#   Enable Hiera's merging function for shield users
+#   Defaults to: false
+#
+#
 # The default values for the parameters are set in elasticsearch::params. Have
 # a look at the corresponding <tt>params.pp</tt> manifest file if you need more
 # technical information about them.
@@ -246,7 +251,8 @@ class elasticsearch(
   $instances             = undef,
   $instances_hiera_merge = false,
   $plugins               = undef,
-  $plugins_hiera_merge   = false
+  $plugins_hiera_merge   = false,
+  $shield_users_merge = false,
 ) inherits elasticsearch::params {
 
   anchor {'elasticsearch::begin': }
@@ -359,6 +365,16 @@ class elasticsearch(
     create_resources('elasticsearch::plugin', $x_plugins)
   }
 
+  # Hiera support for esusers
+  validate_bool($shield_users_merge)
+
+  if $shield_users_merge == true {
+    $esusers = hiera_hash('elasticsearch::esusers', $::elasticsearch::esusers)
+    if $esusers {
+      validate_hash($esusers)
+      create_resources('elasticsearch::shield::esuser', $esusers)
+    }
+  }
 
   if $java_install == true {
     # Install java

--- a/manifests/shield/esuser.pp
+++ b/manifests/shield/esuser.pp
@@ -1,0 +1,30 @@
+#
+# == Class: elasticsearch::shield::esuser
+#
+#  Class to manage creating users in elasticsearch via the shield plugin
+#
+# == Parameters
+#
+#  [*username*]
+#    String to use for a username
+#
+#  [*password*]
+#    String to use for a password
+#
+define elasticsearch::shield::esuser($username, $password, $roles=$title) {
+  if $username == undef {
+    fail('user must be specified')
+  }
+  validate_string($username)
+  if $password == undef {
+    fail('password must be specified')
+  }
+  validate_slength($password, 4192, 6)
+  
+  # TODO: what happens if we add roles - this route we only set role on useradd
+  exec { "useradd shield::esuser::${username}":
+    path    => [ '/usr/bin', '/usr/share/elasticsearch/bin/shield' ],
+    command => "esusers useradd ${username} -p \"${password}\" -r ${roles} &> /dev/null",
+    unless  => "esusers list ${username} &> /dev/null",
+  }
+}

--- a/manifests/shield/esuser.pp
+++ b/manifests/shield/esuser.pp
@@ -23,6 +23,7 @@ define elasticsearch::shield::esuser($username, $password, $roles=$title) {
   
   # TODO: what happens if we add roles - this route we only set role on useradd
   exec { "useradd shield::esuser::${username}":
+    user    => $::elasticsearch::elasticsearch_user,
     path    => [ '/usr/bin', '/usr/share/elasticsearch/bin/shield' ],
     command => "esusers useradd ${username} -p \"${password}\" -r ${roles} &> /dev/null",
     unless  => "esusers list ${username} &> /dev/null",


### PR DESCRIPTION
I am not sure if this is something you guys will want to merge directly. For now it is working for my specific use case.

It does not cover much for shield, only user addition and role assignment/password at the time of creation. If the user password changes this manifest will not cover the case. Ditto if roles change.

Mainly I'm looking to see something along the lines discussed in #433 and #399.

The comment discussed in #433 looks to have some kind of dependency on the plugin manager. I started a [thread](https://discuss.elastic.co/t/question-on-plugin-install-and-configdir/32177) to discuss what I'm trying to accomplish. There seems to be a disconnect in the instances logic and how plugin works/expects things.