### PR TITLE
Fix plugin remove for 2.x

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -149,7 +149,7 @@ define elasticsearch::plugin(
     'installed', 'present': {
       $name_file_path = "${elasticsearch::plugindir}/${plugin_dir}/.name"
       exec {"purge_plugin_${plugin_dir}_old":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} remove ${plugin_dir}",
         onlyif  => "test -e ${elasticsearch::plugindir}/${plugin_dir} && test \"$(cat ${name_file_path})\" != '${name}'",
         before  => Exec["install_plugin_${name}"],
       }
@@ -168,7 +168,7 @@ define elasticsearch::plugin(
     }
     'absent': {
       exec {"remove_plugin_${name}":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} remove ${plugin_dir}",
         onlyif  => "test -d ${elasticsearch::plugindir}/${plugin_dir}",
         notify  => $notify_service,
       }


### PR DESCRIPTION
bin/plugin does not have "--remove" option now, "remove" must be used instead.