### PR TITLE
allow installation of plugins on 2.x

### DIFF
--- a/lib/facter/elasticsearch_version.rb
+++ b/lib/facter/elasticsearch_version.rb
@@ -1,0 +1,21 @@
+# Fact: elasticsearch_version
+#
+# Purpose: get elasticsearch's current version
+#
+# Resolution:
+#   Uses elasticsearch's version flag and parses the result from 'version'
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
+Facter.add(:elasticsearch_version) do
+  setcode do
+    es_exec = Facter::Core::Execution.which('elasticsearch') || '/usr/share/elasticsearch/bin/elasticsearch'
+    es_ver = Facter::Core::Execution.exec("#{es_exec} -v")
+    es_ver = Facter::Core::Execution.exec("#{es_exec} --version") if es_ver == ""
+    es_ver.to_s.lines.first.strip.split[1].chop unless (es_ver.nil? || es_ver == "")
+  end
+end
+

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -77,7 +77,7 @@ define elasticsearch::plugin(
     $proxy_port  = undef,
 ) {
 
-  include elasticsearch
+  include ::elasticsearch
 
   Exec {
     path      => [ '/bin', '/usr/bin', '/usr/local/bin' ],
@@ -91,6 +91,12 @@ define elasticsearch::plugin(
   $notify_service = $elasticsearch::restart_on_change ? {
     false   => undef,
     default => Elasticsearch::Service[$instances],
+  }
+
+  if versioncmp($::elasticsearch_version, '2.0.0') < 0 {
+    $remove_cmd = '--remove'
+  } else {
+    $remove_cmd = 'remove'
   }
 
   if ($module_dir != undef) {
@@ -121,8 +127,8 @@ define elasticsearch::plugin(
 
   if ($source != undef) {
 
-    $filenameArray = split($source, '/')
-    $basefilename = $filenameArray[-1]
+    $filename_array = split($source, '/')
+    $basefilename = $filename_array[-1]
 
     file { "/tmp/${basefilename}":
       ensure => 'file',
@@ -141,7 +147,11 @@ define elasticsearch::plugin(
     $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name}"
     $exec_rets = [0,]
   } else {
-    $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name} --url ${real_url}"
+    if versioncmp($::elasticsearch_version, '2.0.0') < 0 {
+      $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name} --url ${real_url}"
+    } else {
+      $install_cmd = "${elasticsearch::plugintool}${proxy} install ${real_url}"
+    }
     $exec_rets = [0,1]
   }
 
@@ -149,7 +159,7 @@ define elasticsearch::plugin(
     'installed', 'present': {
       $name_file_path = "${elasticsearch::plugindir}/${plugin_dir}/.name"
       exec {"purge_plugin_${plugin_dir}_old":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} ${remove_cmd} ${plugin_dir}",
         onlyif  => "test -e ${elasticsearch::plugindir}/${plugin_dir} && test \"$(cat ${name_file_path})\" != '${name}'",
         before  => Exec["install_plugin_${name}"],
       }
@@ -167,8 +177,9 @@ define elasticsearch::plugin(
       }
     }
     'absent': {
+      $remove = $::elasticsearch
       exec {"remove_plugin_${name}":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
+        command => "${elasticsearch::plugintool} ${remove_cmd} ${plugin_dir}",
         onlyif  => "test -d ${elasticsearch::plugindir}/${plugin_dir}",
         notify  => $notify_service,
       }

--- a/spec/unit/facter/elasticsearch_version_spec.rb
+++ b/spec/unit/facter/elasticsearch_version_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe "elasticsearch_version" do
+    context 'returns elasticsearch version when elasticsearch < 2.0.0 present' do
+      it do
+        es_version_output = <<-EOS
+Version: 1.4.7, Build: de54438/2015-10-22T08:09:48Z, JVM: 1.7.0_71
+        EOS
+        Facter::Core::Execution.expects(:exec).with("/usr/share/elasticsearch/bin/elasticsearch -v").returns(es_version_output)
+        expect(Facter.value(:elasticsearch_version)).to eq("1.4.7")
+      end
+    end
+    context 'returns elasticsearch version when elasticsearch >= 2.0.0 present' do
+      it do
+        es_version_output = <<-EOS
+Version: 2.0.0, Build: de54438/2015-10-22T08:09:48Z, JVM: 1.8.0_66
+        EOS
+        Facter::Core::Execution.expects(:exec).with("/usr/share/elasticsearch/bin/elasticsearch -v").returns("")
+        Facter::Core::Execution.expects(:exec).with("/usr/share/elasticsearch/bin/elasticsearch --version").returns(es_version_output)
+        expect(Facter.value(:elasticsearch_version)).to eq("2.0.0")
+      end
+    end
+
+    context 'returns nil when elasticsearch not present' do
+      it do
+        Facter::Core::Execution.stubs(:exec)
+        expect(Facter.value(:elasticsearch_version)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
this adds a fact, elasitcsearch_version, which works without
elasticsearch running, and helps determine the basic version of the
es installation.

using this info, we then decide in elasticsearch::plugin how to
(un)install plugins.