### PR TITLE
Upgrade apt dependency

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,9 +39,10 @@ class elasticsearch::repo {
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
-        include_src => false,
+        key         => {
+          id     => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          source => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+        }
       }
     }
     'RedHat', 'Linux': {

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.4.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "ceritsc/yum",


### PR DESCRIPTION
Please consider upgrading to apt module version >= 2.0.0

This pull request also fixed the deprecation warnings.