### PR TITLE
Some changes to support OpenBSD:

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ elasticsearch::plugin{ 'jetty':
 }
 ```
 
-
 ####Using a proxy
 You can also use a proxy if required by setting the `proxy_host` and `proxy_port` options:
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,10 +115,12 @@ class elasticsearch::config {
     }
 
     $new_init_defaults = { 'CONF_DIR' => $elasticsearch::configdir }
-    augeas { "${elasticsearch::params::defaults_location}/elasticsearch":
-      incl    => "${elasticsearch::params::defaults_location}/elasticsearch",
-      lens    => 'Shellvars.lns',
-      changes => template("${module_name}/etc/sysconfig/defaults.erb"),
+    if $elasticsearch::params::defaults_location {
+      augeas { "${elasticsearch::params::defaults_location}/elasticsearch":
+        incl    => "${elasticsearch::params::defaults_location}/elasticsearch",
+        lens    => 'Shellvars.lns',
+        changes => template("${module_name}/etc/sysconfig/defaults.erb"),
+      }
     }
 
     file { '/etc/elasticsearch/elasticsearch.yml':

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -64,6 +64,9 @@
 # [*init_defaults_file*]
 #   Defaults file as puppet resource
 #
+# [*service_flags*]
+#   Service flags used for the OpenBSD service configuration, defaults to undef.
+#
 # === Authors
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
@@ -78,6 +81,7 @@ define elasticsearch::instance(
   $logging_config     = undef,
   $logging_template   = undef,
   $logging_level      = $elasticsearch::default_logging_level,
+  $service_flags      = undef,
   $init_defaults      = undef,
   $init_defaults_file = undef,
   $init_template      = $elasticsearch::init_template
@@ -307,6 +311,7 @@ define elasticsearch::instance(
   elasticsearch::service { $name:
     ensure             => $ensure,
     status             => $status,
+    service_flags      => $service_flags,
     init_defaults      => $init_defaults_new,
     init_defaults_file => $init_defaults_file,
     init_template      => $init_template,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -38,21 +38,21 @@ class elasticsearch::package {
   if $elasticsearch::ensure == 'present' {
 
     # Create directory to place the package file
+    $package_dir = $elasticsearch::package_dir
     exec { 'create_package_dir_elasticsearch':
       cwd     => '/',
       path    => ['/usr/bin', '/bin'],
-      command => "mkdir -p ${elasticsearch::package_dir}",
-      creates => $elasticsearch::package_dir,
+      command => "mkdir -p ${package_dir}",
+      creates => $package_dir,
     }
 
-    file { $elasticsearch::package_dir:
+    file { $package_dir:
       ensure  => 'directory',
       purge   => $elasticsearch::purge_package_dir,
       force   => $elasticsearch::purge_package_dir,
       backup  => false,
       require => Exec['create_package_dir_elasticsearch'],
     }
-
 
     # Check if we want to install a specific version or not
     if $elasticsearch::version == false {
@@ -77,7 +77,6 @@ class elasticsearch::package {
         default:   { fail("software provider \"${elasticsearch::package_provider}\".") }
       }
 
-      $package_dir = $elasticsearch::package_dir
 
       $filenameArray = split($elasticsearch::package_url, '/')
       $basefilename = $filenameArray[-1]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,10 @@ class elasticsearch::params {
       $elasticsearch_user  = 'elasticsearch'
       $elasticsearch_group = 'elasticsearch'
     }
+    'OpenBSD': {
+      $elasticsearch_user  = '_elasticsearch'
+      $elasticsearch_group = '_elasticsearch'
+    }
     default: {
       fail("\"${module_name}\" provides no user/group default value
            for \"${::kernel}\"")
@@ -86,6 +90,9 @@ class elasticsearch::params {
     }
     'Darwin': {
       $download_tool = 'curl --insecure -o'
+    }
+    'OpenBSD': {
+      $download_tool = 'ftp -o'
     }
     default: {
       fail("\"${module_name}\" provides no download tool default value
@@ -104,6 +111,16 @@ class elasticsearch::params {
       $plugindir   = "${homedir}/plugins"
       $plugintool  = "${homedir}/bin/plugin"
       $datadir     = '/usr/share/elasticsearch/data'
+    }
+    'OpenBSD': {
+      $configdir   = '/etc/elasticsearch'
+      $logdir      = '/var/log/elasticsearch'
+      $package_dir = '/var/cache/elasticsearch'
+      $installpath = undef
+      $homedir     = '/usr/local/elasticsearch'
+      $plugindir   = "${homedir}/plugins"
+      $plugintool  = "${homedir}/bin/plugin"
+      $datadir     = '/var/elasticsearch/data'
     }
     default: {
       fail("\"${module_name}\" provides no config directory default value
@@ -126,6 +143,9 @@ class elasticsearch::params {
     }
     'Gentoo': {
       $package = [ 'app-misc/elasticsearch' ]
+    }
+    'OpenBSD': {
+      $package = [ 'elasticsearch' ]
     }
     default: {
       fail("\"${module_name}\" provides no package default value
@@ -223,6 +243,16 @@ class elasticsearch::params {
       $defaults_location  = '/etc/conf.d'
       $init_template      = 'elasticsearch.openrc.erb'
       $pid_dir            = '/run/elasticsearch'
+    }
+    'OpenBSD': {
+      $service_name       = 'elasticsearch'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = undef
+      $service_providers  = 'openbsd'
+      $defaults_location  = undef
+      $init_template      = 'elasticsearch.OpenBSD.erb'
+      $pid_dir            = '/var/run/elasticsearch'
     }
     default: {
       fail("\"${module_name}\" provides no service parameters

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -131,6 +131,7 @@ define elasticsearch::plugin(
         source     => $file_source,
         url        => $url,
         proxy_args => $proxy,
+        plugin_dir => $::elasticsearch::plugindir,
         notify     => $notify_service,
       }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -50,6 +50,9 @@
 # [*init_template*]
 #   Service file as a template
 #
+# [*service_flags*]
+#   Service flags, used on OpenBSD for service configuration
+#
 # === Authors
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
@@ -60,6 +63,7 @@ define elasticsearch::service(
   $init_defaults_file = undef,
   $init_defaults      = undef,
   $init_template      = undef,
+  $service_flags      = undef,
 ) {
 
   case $elasticsearch::real_service_provider {
@@ -71,6 +75,14 @@ define elasticsearch::service(
         init_defaults_file => $init_defaults_file,
         init_defaults      => $init_defaults,
         init_template      => $init_template,
+      }
+    }
+    'openbsd': {
+      elasticsearch::service::openbsd { $name:
+        ensure        => $ensure,
+        status        => $status,
+        init_template => $init_template,
+        service_flags => $service_flags,
       }
     }
     'systemd': {

--- a/manifests/service/openbsd.pp
+++ b/manifests/service/openbsd.pp
@@ -1,0 +1,156 @@
+# == Define: elasticsearch::service::openbsd
+#
+# This class exists to coordinate all service management related actions,
+# functionality and logical units in a central place.
+#
+# <b>Note:</b> "service" is the Puppet term and type for background processes
+# in general and is used in a platform-independent way. E.g. "service" means
+# "daemon" in relation to Unix-like systems.
+#
+#
+# === Parameters
+#
+# [*ensure*]
+#   String. Controls if the managed resources shall be <tt>present</tt> or
+#   <tt>absent</tt>. If set to <tt>absent</tt>:
+#   * The managed software packages are being uninstalled.
+#   * Any traces of the packages will be purged as good as possible. This may
+#     include existing configuration files. The exact behavior is provider
+#     dependent. Q.v.:
+#     * Puppet type reference: {package, "purgeable"}[http://j.mp/xbxmNP]
+#     * {Puppet's package provider source code}[http://j.mp/wtVCaL]
+#   * System modifications (if any) will be reverted as good as possible
+#     (e.g. removal of created users, services, changed log settings, ...).
+#   * This is thus destructive and should be used with care.
+#   Defaults to <tt>present</tt>.
+#
+# [*status*]
+#   String to define the status of the service. Possible values:
+#   * <tt>enabled</tt>: Service is running and will be started at boot time.
+#   * <tt>disabled</tt>: Service is stopped and will not be started at boot
+#     time.
+#   * <tt>running</tt>: Service is running but will not be started at boot time.
+#     You can use this to start a service on the first Puppet run instead of
+#     the system startup.
+#   * <tt>unmanaged</tt>: Service will not be started at boot time and Puppet
+#     does not care whether the service is running or not. For example, this may
+#     be useful if a cluster management software is used to decide when to start
+#     the service plus assuring it is running on the desired node.
+#   Defaults to <tt>enabled</tt>. The singular form ("service") is used for the
+#   sake of convenience. Of course, the defined status affects all services if
+#   more than one is managed (see <tt>service.pp</tt> to check if this is the
+#   case).
+#
+# [*pid_dir*]
+#   String, directory where to store the serice pid file
+#
+# [*init_template*]
+#   Service file as a template
+#
+# [*service_flags*]
+#   String, flags to pass to the service
+#
+# === Authors
+#
+# * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
+#
+define elasticsearch::service::openbsd(
+  $ensure             = $elasticsearch::ensure,
+  $status             = $elasticsearch::status,
+  $pid_dir            = $elasticsearch::pid_dir,
+  $init_template      = $elasticsearch::init_template,
+  $service_flags      = undef,
+) {
+
+  #### Service management
+
+  # set params: in operation
+  if $ensure == 'present' {
+
+    case $status {
+      # make sure service is currently running, start it on boot
+      'enabled': {
+        $service_ensure = 'running'
+        $service_enable = true
+      }
+      # make sure service is currently stopped, do not start it on boot
+      'disabled': {
+        $service_ensure = 'stopped'
+        $service_enable = false
+      }
+      # make sure service is currently running, do not start it on boot
+      'running': {
+        $service_ensure = 'running'
+        $service_enable = false
+      }
+      # do not start service on boot, do not care whether currently running
+      # or not
+      'unmanaged': {
+        $service_ensure = undef
+        $service_enable = false
+      }
+      # unknown status
+      # note: don't forget to update the parameter check in init.pp if you
+      #       add a new or change an existing status.
+      default: {
+        fail("\"${status}\" is an unknown service status value")
+      }
+    }
+
+  # set params: removal
+  } else {
+
+    # make sure the service is stopped and disabled (the removal itself will be
+    # done by package.pp)
+    $service_ensure = 'stopped'
+    $service_enable = false
+
+  }
+
+  $notify_service = $elasticsearch::restart_on_change ? {
+    true  => Service["elasticsearch-instance-${name}"],
+    false => undef,
+  }
+
+  if ( $status != 'unmanaged' and $ensure == 'present' ) {
+
+    # init file from template
+    if ($init_template != undef) {
+
+      file { "/etc/rc.d/elasticsearch_${name}":
+        ensure  => $ensure,
+        content => template($init_template),
+        owner   => 'root',
+        group   => '0',
+        mode    => '0555',
+        before  => Service["elasticsearch-instance-${name}"],
+        notify  => $notify_service,
+      }
+
+    }
+
+  } elsif ($status != 'unmanaged') {
+
+    file { "/etc/rc.d/elasticsearch_${name}":
+      ensure    => 'absent',
+      subscribe => Service["elasticsearch-instance-${name}"],
+    }
+
+  }
+
+  if ( $status != 'unmanaged') {
+
+    # action
+    service { "elasticsearch-instance-${name}":
+      ensure     => $service_ensure,
+      enable     => $service_enable,
+      name       => "elasticsearch_${name}",
+      flags      => $service_flags,
+      hasstatus  => $elasticsearch::params::service_hasstatus,
+      hasrestart => $elasticsearch::params::service_hasrestart,
+      pattern    => $elasticsearch::params::service_pattern,
+    }
+
+  }
+
+}

--- a/templates/etc/init.d/elasticsearch.OpenBSD.erb
+++ b/templates/etc/init.d/elasticsearch.OpenBSD.erb
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# This file is managed via PUPPET
+
+daemon="/usr/local/elasticsearch/bin/elasticsearch"
+daemon_flags="-d -Des.default.path.conf=/etc/elasticsearch/<%= @name %> -p <%= @pid_dir %>/elasticsearch-<%= @name %>.pid"
+daemon_user="_elasticsearch"
+
+. /etc/rc.d/rc.subr
+
+pexp="$(/usr/local/bin/javaPathHelper -c elasticsearch) .*org.elasticsearch.bootstrap.Elasticsearch.*"
+
+rc_reload=NO
+
+rc_start() {
+	${rcexec} \
+		"ES_INCLUDE=\"/etc/elasticsearch/elasticsearch.in.sh\" \
+		"CONF_DIR=\"/etc/elasticsearch\"" \
+		JAVA_HOME=\"$(/usr/local/bin/javaPathHelper -h elasticsearch)\" \
+		${daemon} ${daemon_flags}"
+}
+
+rc_pre() {
+	install -d -o _elasticsearch /var/run/elasticsearch/
+}
+
+rc_cmd $1


### PR DESCRIPTION
 * a couple of OpenBSD specific additions to params.pp, i.e. user,
   download tool, paths, service provider, etc.
 * add a $service_flags parameter to instance.pp, since the OpenBSD
   service type supports flags, and those should be settable.
 * add a $service_flags parameter to service.pp, that gets passed
   in from instance.pp, and handed over to openbsd.pp service.
 * add an easy openbsd service provider, that only knows about
   status, ensure, pid_dir, service_flags and init_template
   parameters. There is no "standard" defaults file on OpenBSD.
 * because the defaults_location on OpenBSD is not set, guard
   the augeas call in config.pp to manage the defaults file.
 * added a template for the openbsd service, based on the
   rc script, that comes with the package.


tested with elasticsearch-1.7.2, configured and fired up an instance as well as plugin installation works.

Let me know if there is something that needs change/enhancement to get merged.

thanks,
Sebastian