### PR TITLE
repo_key_id to param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,14 @@
 # [*repo_version*]
 #   Our repositories are versioned per major version (0.90, 1.0) select here which version you want
 #
+# [*repo_key_id*]
+#   String.  The apt GPG key id
+#   Default: D88E42B4
+#
+# [*repo_key_source*]
+#   String.  URL of the apt GPG key
+#   Default: http://packages.elastic.co/GPG-KEY-elasticsearch
+#
 # [*logging_config*]
 #   Hash representation of information you want in the logging.yml file
 #
@@ -228,6 +236,8 @@ class elasticsearch(
   $java_package          = undef,
   $manage_repo           = false,
   $repo_version          = undef,
+  $repo_key_id           = 'D88E42B4',
+  $repo_key_source       = 'http://packages.elastic.co/GPG-KEY-elasticsearch',
   $logging_file          = undef,
   $logging_config        = undef,
   $logging_template      = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,8 +39,8 @@ class elasticsearch::repo {
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+        key         => $::elasticsearch::repo_key_id,
+        key_source  => $::elasticsearch::repo_key_source,
         include_src => false,
       }
     }
@@ -49,14 +49,14 @@ class elasticsearch::repo {
         descr    => 'elasticsearch repo',
         baseurl  => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/centos",
         gpgcheck => 1,
-        gpgkey   => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+        gpgkey   => $::elasticsearch::repo_key_source,
         enabled  => 1,
       }
     }
     'Suse': {
       exec { 'elasticsearch_suse_import_gpg':
-        command => 'rpmkeys --import http://packages.elastic.co/GPG-KEY-elasticsearch',
-        unless  => 'test $(rpm -qa gpg-pubkey | grep -i "D88E42B4" | wc -l) -eq 1 ',
+        command => "rpmkeys --import ${::elasticsearch::repo_key_source}",
+        unless  => "test $(rpm -qa gpg-pubkey | grep -i '${::elasticsearch::repo_key_id}' | wc -l) -eq 1 ",
         notify  => [ Zypprepo['elasticsearch'] ],
       }
 
@@ -66,7 +66,7 @@ class elasticsearch::repo {
         autorefresh => 1,
         name        => 'elasticsearch',
         gpgcheck    => 1,
-        gpgkey      => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+        gpgkey      => $::elasticsearch::repo_key_source,
         type        => 'yum',
       }
     }


### PR DESCRIPTION
Move the repo_key to a Param, in order to keep support for older PE version and still can use the long key with the new apt module