### PR TITLE
add minimal SLES 12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This module has been tested against all versions of ES 1.x (ES 1.0 - 1.7). **The
 When using the repository management you will need the following dependency modules:
 
 * Debian/Ubuntu: [Puppetlabs/apt](http://forge.puppetlabs.com/puppetlabs/apt) Version 1.8.x or lower.
-* OpenSuSE: [Darin/zypprepo](https://forge.puppetlabs.com/darin/zypprepo)
+* OpenSuSE/SLES: [Darin/zypprepo](https://forge.puppetlabs.com/darin/zypprepo)
 
 ##Usage
 
@@ -514,6 +514,7 @@ The module has been tested on:
 * CentOS 6/7
 * Ubuntu 12.04, 14.04
 * OpenSuSE 13.x
+* SLES 12
 
 Other distro's that have been reported to work:
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,7 +121,7 @@ class elasticsearch::params {
       # main application
       $package = [ 'elasticsearch' ]
     }
-    'OpenSuSE': {
+    'OpenSuSE', 'SLES': {
       $package = [ 'elasticsearch' ]
     }
     default: {
@@ -141,8 +141,9 @@ class elasticsearch::params {
       $pid_dir            = '/var/run/elasticsearch'
 
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
+        $init_template         = 'elasticsearch.systemd.erb'
+        $service_providers     = 'systemd'
+        $system_service_folder = '/lib/systemd/system'
       } else {
         $init_template     = 'elasticsearch.RedHat.erb'
         $service_providers = 'init'
@@ -166,9 +167,10 @@ class elasticsearch::params {
       $service_pattern    = $service_name
       $defaults_location  = '/etc/default'
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
-        $pid_dir           = '/var/run/elasticsearch'
+        $init_template         = 'elasticsearch.systemd.erb'
+        $service_providers     = 'systemd'
+        $system_service_folder = '/lib/systemd/system'
+        $pid_dir               = '/var/run/elasticsearch'
       } else {
         $init_template     = 'elasticsearch.Debian.erb'
         $service_providers = [ 'init' ]
@@ -183,9 +185,10 @@ class elasticsearch::params {
       $defaults_location  = '/etc/default'
 
       if versioncmp($::operatingsystemmajrelease, '15') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
-        $pid_dir           = '/var/run/elasticsearch'
+        $init_template         = 'elasticsearch.systemd.erb'
+        $service_providers     = 'systemd'
+        $system_service_folder = '/lib/systemd/system'
+        $pid_dir               = '/var/run/elasticsearch'
       } else {
         $init_template     = 'elasticsearch.Debian.erb'
         $service_providers = [ 'init' ]
@@ -201,15 +204,20 @@ class elasticsearch::params {
       $defaults_location  = false
       $pid_dir            = false
     }
-    'OpenSuSE': {
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $service_providers  = 'systemd'
-      $defaults_location  = '/etc/sysconfig'
-      $init_template      = 'elasticsearch.systemd.erb'
-      $pid_dir            = '/var/run/elasticsearch'
+    'OpenSuSE', 'SLES': {
+      $service_name          = 'elasticsearch'
+      $service_hasrestart    = true
+      $service_hasstatus     = true
+      $service_pattern       = $service_name
+      $service_providers     = 'systemd'
+      $defaults_location     = '/etc/sysconfig'
+      $init_template         = 'elasticsearch.systemd.erb'
+      $pid_dir               = '/var/run/elasticsearch'
+      if $::operatingsystem == 'OpenSuSE' and versioncmp($::operatingsystemmajrelease, '12') <= 0 {
+        $system_service_folder = '/lib/systemd/system'
+      } else {
+        $system_service_folder = '/usr/lib/systemd/system'
+      }
     }
     default: {
       fail("\"${module_name}\" provides no service parameters

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -163,7 +163,7 @@ define elasticsearch::service::systemd(
         $memlock = undef
       }
 
-      file { "/lib/systemd/system/elasticsearch-${name}.service":
+      file { "${elasticsearch::params::system_service_folder}/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),
         before  => Service["elasticsearch-instance-${name}"],
@@ -176,7 +176,7 @@ define elasticsearch::service::systemd(
 
   } elsif($status != 'unmanaged') {
 
-    file { "/lib/systemd/system/elasticsearch-${name}.service":
+    file { "${elasticsearch::params::system_service_folder}/elasticsearch-${name}.service":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"],

--- a/metadata.json
+++ b/metadata.json
@@ -81,6 +81,12 @@
         "12",
         "13"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12.0"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -13,6 +13,7 @@ describe 'elasticsearch', :type => 'class' do
       case facts[:osfamily]
       when 'Debian'
         let(:defaults_path) { '/etc/default' }
+        let(:system_service_folder) { '/lib/systemd/system' }
         let(:pkg_ext) { 'deb' }
         let(:pkg_prov) { 'dpkg' }
         let(:version_add) { '' }
@@ -23,6 +24,7 @@ describe 'elasticsearch', :type => 'class' do
         end
       when 'RedHat'
         let(:defaults_path) { '/etc/sysconfig' }
+        let(:system_service_folder) { '/lib/systemd/system' }
         let(:pkg_ext) { 'rpm' }
         let(:pkg_prov) { 'rpm' }
         let(:version_add) { '-1' }
@@ -36,6 +38,7 @@ describe 'elasticsearch', :type => 'class' do
         let(:pkg_ext) { 'rpm' }
         let(:pkg_prov) { 'rpm' }
         let(:version_add) { '-1' }
+        let(:system_service_folder) { '/usr/lib/systemd/system' }
       end
 
       let(:facts) do
@@ -64,18 +67,18 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/lib') }
         it { should contain_file('/usr/share/elasticsearch/plugins') }
         it { should contain_file('/usr/share/elasticsearch/bin').with(:mode => '0755') }
-	it { should contain_augeas("#{defaults_path}/elasticsearch") }
+        it { should contain_augeas("#{defaults_path}/elasticsearch") }
 
         # Base files
         if test_pid == true
           it { should contain_file('/usr/lib/tmpfiles.d/elasticsearch.conf') }
         end
 
-	# file removal from package
-	it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
-	it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
+        # file removal from package
+        it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
+        it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
       end
 
       context 'package installation' do

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -78,8 +78,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       context "Set via file" do
         let :params do {
           :ensure => 'present',
-	  :status => 'enabled',
-	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+          :status => 'enabled',
+          :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
         } end
 
         it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -88,8 +88,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       context "Set via hash" do
         let :params do {
           :ensure => 'present',
-  	  :status => 'enabled',
-  	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+          :status => 'enabled',
+          :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
         } end
 
         it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }


### PR DESCRIPTION
Unlike #375, this PR does the bare minimum necessary to support SLES12 and therefore uses the same systemd service definition as for other distros. The ```rpmkeys``` problem mentioned in #375 is also a non-issue for SLES 12.