### PR TITLE
Addendum for PR #494, With Tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@
 #
 # [*proxy_url*]
 #   For http and https downloads you can set a proxy server to use
-#   Format: proto://[user:pass@]server[:port]/ 
+#   Format: proto://[user:pass@]server[:port]/
 #   Defaults to: undef (proxy disabled)
 #
 # [*elasticsearch_user*]

--- a/spec/classes/005_elasticsearch_repo_spec.rb
+++ b/spec/classes/005_elasticsearch_repo_spec.rb
@@ -97,8 +97,8 @@ describe 'elasticsearch', :type => 'class' do
         case facts[:osfamily]
         when 'Debian'
           context 'has override apt key' do
-            it { is_expected.to contain_apt__key('46095ACC8548582C1A2699A9D27D666CD88E42B4').with({
-              :key_source => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+            it { is_expected.to contain_apt__source('elasticsearch').with({
+              :key => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
             })}
           end
         when 'Suse'
@@ -122,7 +122,7 @@ describe 'elasticsearch', :type => 'class' do
         case facts[:osfamily]
         when 'Debian'
           context 'has override apt key' do
-            it { is_expected.to contain_apt__key('D88E42B4').with({
+            it { is_expected.to contain_apt__source('elasticsearch').with({
               :key_source => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch',
             })}
           end

--- a/spec/classes/005_elasticsearch_repo_spec.rb
+++ b/spec/classes/005_elasticsearch_repo_spec.rb
@@ -85,7 +85,59 @@ describe 'elasticsearch', :type => 'class' do
         end
 
       end
-    
+
+      context "Override repo key ID" do
+
+        let :params do
+          default_params.merge({
+            :repo_key_id => '46095ACC8548582C1A2699A9D27D666CD88E42B4'
+          })
+        end
+
+        case facts[:osfamily]
+        when 'Debian'
+          context 'has override apt key' do
+            it { is_expected.to contain_apt__key('46095ACC8548582C1A2699A9D27D666CD88E42B4').with({
+              :key_source => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+            })}
+          end
+        when 'Suse'
+          context 'has override yum key' do
+            it { is_expected.to contain_exec('elasticsearch_suse_import_gpg').with({
+              :unless  => "test $(rpm -qa gpg-pubkey | grep -i '46095ACC8548582C1A2699A9D27D666CD88E42B4' | wc -l) -eq 1 ",
+            })}
+          end
+        end
+
+      end
+
+      context "Override repo source URL" do
+
+        let :params do
+          default_params.merge({
+            :repo_key_source => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch'
+          })
+        end
+
+        case facts[:osfamily]
+        when 'Debian'
+          context 'has override apt key' do
+            it { is_expected.to contain_apt__key('D88E42B4').with({
+              :key_source => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+            })}
+          end
+        when 'RedHat'
+          context 'has override yum key source' do
+            it { should contain_yumrepo('elasticsearch').with(:gpgkey => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch') }
+          end
+        when 'Suse'
+          context 'has override yum key source' do
+            it { should contain_exec('elasticsearch_suse_import_gpg').with(:command => 'rpmkeys --import http://packages.elastic.co/GPG-KEY-elasticsearch') }
+          end
+        end
+
+      end
+
     end
   end
 end

--- a/spec/classes/005_elasticsearch_repo_spec.rb
+++ b/spec/classes/005_elasticsearch_repo_spec.rb
@@ -121,7 +121,7 @@ describe 'elasticsearch', :type => 'class' do
 
         case facts[:osfamily]
         when 'Debian'
-          context 'has override apt key' do
+          context 'has override apt key source' do
             it { is_expected.to contain_apt__source('elasticsearch').with({
               :key_source => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch',
             })}
@@ -132,7 +132,7 @@ describe 'elasticsearch', :type => 'class' do
           end
         when 'Suse'
           context 'has override yum key source' do
-            it { should contain_exec('elasticsearch_suse_import_gpg').with(:command => 'rpmkeys --import http://packages.elastic.co/GPG-KEY-elasticsearch') }
+            it { should contain_exec('elasticsearch_suse_import_gpg').with(:command => 'rpmkeys --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch') }
           end
         end
 


### PR DESCRIPTION
I hope I'm not stepping on toes, just anxious to get rid of the apt-key warnings with ES! This PR has the items from #494, as well as rpsec tests for both $repo_key_id and $repo_key_source.