### PR TITLE
Updating apt::source call to remove the Puppet warning.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@
 #
 # [*proxy_url*]
 #   For http and https downloads you can set a proxy server to use
-#   Format: proto://[user:pass@]server[:port]/ 
+#   Format: proto://[user:pass@]server[:port]/
 #   Defaults to: undef (proxy disabled)
 #
 # [*elasticsearch_user*]

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,8 @@ class elasticsearch::repo {
         location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+        key_server  => 'pgp.mit.edu',
         key_source  => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Hi there

I quickly updated the apt::source call to remove the fingerprint warnings that were casted during the puppet run.

/dasrecht