### PR TITLE
Export es_include

### DIFF
--- a/templates/etc/init.d/elasticsearch.Debian.erb
+++ b/templates/etc/init.d/elasticsearch.Debian.erb
@@ -111,6 +111,7 @@ export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_CLASSPATH
+export ES_INCLUDE
 
 # Check DAEMON exists
 test -x $DAEMON || exit 0

--- a/templates/etc/init.d/elasticsearch.RedHat.erb
+++ b/templates/etc/init.d/elasticsearch.RedHat.erb
@@ -43,6 +43,7 @@ export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_CLASSPATH
 export JAVA_HOME 
+export ES_INCLUDE
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
Export ES_INCLUDE variable ensuring this is pick up from the right default file otherwise it will only use /usr/share/elasticsearch/elasticsearch.in.sh