### PR TITLE
Added ES_GC_LOG_FILE export in init files

### DIFF
--- a/templates/etc/init.d/elasticsearch.Debian.erb
+++ b/templates/etc/init.d/elasticsearch.Debian.erb
@@ -112,6 +112,7 @@ export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_CLASSPATH
 export ES_INCLUDE
+export ES_GC_LOG_FILE
 
 # Check DAEMON exists
 test -x $DAEMON || exit 0

--- a/templates/etc/init.d/elasticsearch.RedHat.erb
+++ b/templates/etc/init.d/elasticsearch.RedHat.erb
@@ -44,6 +44,7 @@ export ES_JAVA_OPTS
 export ES_CLASSPATH
 export JAVA_HOME 
 export ES_INCLUDE
+export ES_GC_LOG_FILE
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
Per the official distribution init.d files which contain this line:
https://github.com/elastic/elasticsearch/blob/8ffb63a177679141da65981c41340a929ed4ae2d/distribution/rpm/src/main/packaging/init.d/elasticsearch#L66
https://github.com/elastic/elasticsearch/blob/8ffb63a177679141da65981c41340a929ed4ae2d/distribution/deb/src/main/packaging/init.d/elasticsearch#L108

If this is in by default, it doesn't alter or harm anything.  It also allows me to add ES_GC_LOG_FILE to my init_defaults hash, and have it work without having to add a conditional to the template file.

Closes #538 