### PR TITLE
Solve issues with ES being run

### DIFF
--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -90,9 +90,7 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
   def es_version
     return @es_version if @es_version
     begin
-      version = es('-v') # ES 1.x
-    rescue
-      version = es('--version') # ES 2.x
+      version = es('-version')
     rescue
       raise "Unknown ES version. Got #{version.inspect}"
     ensure

--- a/spec/unit/provider/plugin_spec.rb
+++ b/spec/unit/provider/plugin_spec.rb
@@ -21,7 +21,7 @@ describe provider_class do
 
   describe "ES 1.x" do
     before(:each) do
-      provider_class.expects(:es).with('-v').returns("Version: 1.7.1, Build: b88f43f/2015-07-29T09:54:16Z, JVM: 1.7.0_79")
+      provider_class.expects(:es).with('-version').returns("Version: 1.7.1, Build: b88f43f/2015-07-29T09:54:16Z, JVM: 1.7.0_79")
       allow(File).to receive(:open)
       provider.es_version
     end
@@ -67,8 +67,7 @@ describe provider_class do
   describe "ES 2.x" do
 
     before(:each) do
-      allow(provider_class).to receive(:es).with('-v').and_raise(Puppet::ExecutionFailure)
-      allow(provider_class).to receive(:es).with('--version').and_return("Version: 2.0.0, Build: de54438/2015-10-22T08:09:48Z, JVM: 1.8.0_66")
+      allow(provider_class).to receive(:es).with('-version').and_return("Version: 2.0.0, Build: de54438/2015-10-22T08:09:48Z, JVM: 1.8.0_66")
       allow(File).to receive(:open)
       provider.es_version
     end

--- a/spec/unit/type/plugin_spec.rb
+++ b/spec/unit/type/plugin_spec.rb
@@ -47,7 +47,7 @@ end
         )
         allow(File).to receive(:open)
         provider = prov_c.new(resource)
-        provider.expects(:es).with('-v').returns('Version: 1.7.3, Build: b88f43f/2015-07-29T09:54:16Z, JVM: 1.7.0_79')
+        provider.expects(:es).with('-version').returns('Version: 1.7.3, Build: b88f43f/2015-07-29T09:54:16Z, JVM: 1.7.0_79')
         provider.expects(:plugin).with(['install', ['lmenezes/elasticsearch-kopf']])
         provider.create
       end


### PR DESCRIPTION
In some weird cases it could happen that with the first command ES 2.x
would actually startup instead of fail.
This uses the version flag for ES 2.x but also works on 1.x which
ignores everything after -v

Closes #528