### PR TITLE
Still create init script when status is unmanaged

### DIFF
--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -113,7 +113,7 @@ define elasticsearch::service::init(
   }
 
 
-  if ( $status != 'unmanaged' and $ensure == 'present' ) {
+  if ( $ensure == 'present' ) {
 
     # defaults file content. Either from a hash or file
     if ($init_defaults_file != undef) {
@@ -127,11 +127,13 @@ define elasticsearch::service::init(
         notify => $notify_service,
       }
 
-    } elsif ($init_defaults != undef and is_hash($init_defaults) ) {
+    } else {
 
-      if(has_key($init_defaults, 'ES_USER')) {
-        if($init_defaults['ES_USER'] != $elasticsearch::elasticsearch_user) {
-          fail('Found ES_USER setting for init_defaults but is not same as elasticsearch_user setting. Please use elasticsearch_user setting.')
+      if ($init_defaults != undef and is_hash($init_defaults) ) {
+        if(has_key($init_defaults, 'ES_USER')) {
+          if($init_defaults['ES_USER'] != $elasticsearch::elasticsearch_user) {
+            fail('Found ES_USER setting for init_defaults but is not same as elasticsearch_user setting. Please use elasticsearch_user setting.')
+          }
         }
       }
 
@@ -163,7 +165,7 @@ define elasticsearch::service::init(
 
     }
 
-  } elsif ($status != 'unmanaged') {
+  } else {
 
     file { "/etc/init.d/elasticsearch-${name}":
       ensure    => 'absent',
@@ -177,19 +179,15 @@ define elasticsearch::service::init(
 
   }
 
-
-  if ( $status != 'unmanaged') {
-
-    # action
-    service { "elasticsearch-instance-${name}":
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      name       => "elasticsearch-${name}",
-      hasstatus  => $elasticsearch::params::service_hasstatus,
-      hasrestart => $elasticsearch::params::service_hasrestart,
-      pattern    => $elasticsearch::params::service_pattern,
-    }
-
+  # action
+  service { "elasticsearch-instance-${name}":
+    ensure     => $service_ensure,
+    enable     => $service_enable,
+    name       => "elasticsearch-${name}",
+    hasstatus  => $elasticsearch::params::service_hasstatus,
+    hasrestart => $elasticsearch::params::service_hasrestart,
+    pattern    => $elasticsearch::params::service_pattern,
   }
+
 
 }

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -108,7 +108,7 @@ define elasticsearch::service::systemd(
     false => Exec["systemd_reload_${name}"]
   }
 
-  if ( $status != 'unmanaged' and $ensure == 'present' ) {
+  if ( $ensure == 'present' ) {
 
     # defaults file content. Either from a hash or file
     if ($init_defaults_file != undef) {
@@ -174,7 +174,7 @@ define elasticsearch::service::systemd(
 
   $service_require = Exec["systemd_reload_${name}"]
 
-  } elsif($status != 'unmanaged') {
+  } else {
 
     file { "/lib/systemd/system/elasticsearch-${name}.service":
       ensure    => 'absent',
@@ -197,20 +197,16 @@ define elasticsearch::service::systemd(
     refreshonly => true,
   }
 
-  if ($status != 'unmanaged') {
-
-    # action
-    service { "elasticsearch-instance-${name}":
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      name       => "elasticsearch-${name}.service",
-      hasstatus  => $elasticsearch::params::service_hasstatus,
-      hasrestart => $elasticsearch::params::service_hasrestart,
-      pattern    => $elasticsearch::params::service_pattern,
-      provider   => 'systemd',
-      require    => $service_require,
-    }
-
+  # action
+  service { "elasticsearch-instance-${name}":
+    ensure     => $service_ensure,
+    enable     => $service_enable,
+    name       => "elasticsearch-${name}.service",
+    hasstatus  => $elasticsearch::params::service_hasstatus,
+    hasrestart => $elasticsearch::params::service_hasrestart,
+    pattern    => $elasticsearch::params::service_pattern,
+    provider   => 'systemd',
+    require    => $service_require,
   }
 
 }

--- a/spec/defines/010_elasticsearch_service_init_spec.rb
+++ b/spec/defines/010_elasticsearch_service_init_spec.rb
@@ -42,9 +42,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
       } end
 
     it { should contain_elasticsearch__service__init('es-01') }
-      it { should_not contain_service('elasticsearch-instance-es-01') }
-      it { should_not contain_file('/etc/init.d/elasticsearch-es-01') }
-      it { should_not contain_file('/etc/sysconfig/elasticsearch-es-01') }
+    it { should contain_service('elasticsearch-instance-es-01').with(:enable => false) }
+    it { should contain_augeas('defaults_es-01') }
 
   end
 

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -43,10 +43,10 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       :status => 'unmanaged'
     } end
 
+
     it { should contain_elasticsearch__service__systemd('es-01') }
-    it { should_not contain_service('elasticsearch-instance-es-01') }
-    it { should_not contain_file('/lib/systemd/system/elasticsearch-es-01.service') }
-    it { should_not contain_file('/etc/sysconfig/elasticsearch-es-01') }
+    it { should contain_service('elasticsearch-instance-es-01').with(:enable => false) }
+    it { should contain_augeas('defaults_es-01') }
 
   end
 


### PR DESCRIPTION
When we set the service status to unmanaged we still need to create the
init script so they can manage the service via other tooling.

Closes #482
Closes #499
Closes #541