### PR TITLE
Manage elasticsearch templates with hiera binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ elasticsearch::instance { 'es-01': }
 This will set up its own data directory and set the node name to `$hostname-$instance_name`
 
 ####Advanced options
-
 Instance specific options can be given:
 
 ```puppet
@@ -114,19 +113,37 @@ See [Advanced features](#advanced-features) for more information
 Install [a variety of plugins](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-plugins.html#known-plugins). Note that `module_dir` is where the plugin will install itself to and must match that published by the plugin author; it is not where you would like to install it yourself.
 
 ####From official repository
+Direclty inside puppet code:
 ```puppet
 elasticsearch::plugin{'lmenezes/elasticsearch-kopf':
   instances  => 'instance_name'
 }
 ```
+or with hiera binding:
+```YAML
+---
+elasticsearch::plugins:
+    lmenezes/elasticsearch-kopf:
+        instances: 'instance_name'
+```
+
+
 ####From custom url
+Direclty inside puppet code:
 ```puppet
 elasticsearch::plugin{ 'jetty':
   url        => 'https://oss-es-plugins.s3.amazonaws.com/elasticsearch-jetty/elasticsearch-jetty-1.2.1.zip',
   instances  => 'instance_name'
 }
 ```
-
+or with hiera binding:
+```YAML
+---
+elasticsearch::plugins:
+    jetty:
+        url: 'https://oss-es-plugins.s3.amazonaws.com/elasticsearch-jetty/elasticsearch-jetty-1.2.1.zip'
+        instances: 'instance_name'
+```
 
 ####Using a proxy
 You can also use a proxy if required by setting the `proxy_host` and `proxy_port` options:
@@ -136,6 +153,15 @@ elasticsearch::plugin { 'lmenezes/elasticsearch-kopf',
   proxy_host => 'proxy.host.com',
   proxy_port => 3128
 }
+```
+or with hiera binding:
+```YAML
+---
+elasticsearch::plugins:
+    lmenezes/elasticsearch-kopf:
+        instances: 'instance_name'
+        proxy_host: 'proxy.host.com'
+        proxy_port: 3128
 ```
 
 #####Plugin name could be:
@@ -189,6 +215,14 @@ elasticsearch::template { 'templatename':
 }
 ```
 
+The same result could be achieved with hiera:
+```YAML
+---
+elasticsearch::templates :
+    templatename :
+        file : 'puppet:///path/to/template.json'
+```
+
 #### Add a new template using content
 
 This will install and/or replace the template in Elasticsearch:
@@ -197,6 +231,17 @@ This will install and/or replace the template in Elasticsearch:
 elasticsearch::template { 'templatename':
   content => '{"template":"*","settings":{"number_of_replicas":0}}'
 }
+```
+
+The same result could be achieved with hiera:
+```YAML
+---
+elasticsearch::templates :
+    templatename :
+        content :
+            template: "*"
+            settings:
+                number_of_replicas: 0
 ```
 
 #### Delete a template
@@ -281,7 +326,7 @@ class { 'elasticsearch':
 ```
 Setting proxy_url to a location will enable download using the provided proxy
 server. This parameter is also used by elasticsearch::plugin. Setting the port
-in the proxy_url is mandatory. proxy_url defaults to undef (proxy disabled). 
+in the proxy_url is mandatory. proxy_url defaults to undef (proxy disabled).
 
 #####puppet://
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,14 @@
 #   Enable Hiera's merging function for the plugins
 #   Defaults to: false
 #
+# [*templates*]
+#   Define templates via a hash. This is mainly used with Hiera's auto binding
+#   Defaults to: undef
+#
+# [*templates_hiera_merge*]
+#   Enable Hiera's merging function for the templates
+#   Defaults to: false
+#
 # [*package_pin*]
 #   Enables package version pinning.
 #   This pins the package version to the set version number and avoids
@@ -246,7 +254,9 @@ class elasticsearch(
   $instances             = undef,
   $instances_hiera_merge = false,
   $plugins               = undef,
-  $plugins_hiera_merge   = false
+  $plugins_hiera_merge   = false,
+  $templates             = undef,
+  $templates_hiera_merge = false,
 ) inherits elasticsearch::params {
 
   anchor {'elasticsearch::begin': }
@@ -359,6 +369,19 @@ class elasticsearch(
     create_resources('elasticsearch::plugin', $x_plugins)
   }
 
+  # Hiera support for templates
+  validate_bool($templates_hiera_merge)
+
+  if $templates_hiera_merge == true {
+    $x_templates = hiera_hash('elasticsearch::templates', $::elasticsearch::templates)
+  } else {
+    $x_templates = $templates
+  }
+
+  if $x_templates {
+    validate_hash($x_templates)
+    create_resources('elasticsearch::template', $x_templates)
+  }
 
   if $java_install == true {
     # Install java

--- a/spec/acceptance/014_hiera_spec.rb
+++ b/spec/acceptance/014_hiera_spec.rb
@@ -96,8 +96,53 @@ describe "Hiera tests" do
 
   end
 
-  describe "multiple instances" do
+  describe "single instance with template" do
 
+    it 'should run successfully' do
+      write_hiera_config(['singletemplate'])
+      pp = "class { 'elasticsearch': manage_repo => true, repo_version => '#{test_settings['repo_version']}', java_install => true }"
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    end
+
+    describe service(test_settings['service_name_a']) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe package(test_settings['package_name']) do
+      it { should be_installed }
+    end
+
+    describe file(test_settings['pid_file_a']) do
+      it { should be_file }
+      its(:content) { should match /[0-9]+/ }
+    end
+
+    describe "Elasticsearch serves requests on" do
+      it {
+        curl_with_retries("check ES on #{test_settings['port_a']}", default, "http://localhost:#{test_settings['port_a']}/?pretty=true", 0)
+      }
+    end
+
+    describe file('/etc/elasticsearch/es-01/elasticsearch.yml') do
+      it { should be_file }
+      it { should contain 'name: es-01' }
+    end
+
+    describe file('/usr/share/elasticsearch/templates_import') do
+      it { should be_directory }
+    end
+
+    it 'should report as existing in Elasticsearch' do
+      curl_with_retries('validate template as installed', default, "http://localhost:#{test_settings['port_a']}/_template/foo | grep logstash", 0)
+    end
+
+  end
+
+  describe "multiple instances" do
 
     it 'should run successfully' do
       write_hiera_config(['multipleinstances'])

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -64,18 +64,18 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/lib') }
         # it { should contain_file('/usr/share/elasticsearch/plugins') }
         it { should contain_file('/usr/share/elasticsearch/bin').with(:mode => '0755') }
-	it { should contain_augeas("#{defaults_path}/elasticsearch") }
+        it { should contain_augeas("#{defaults_path}/elasticsearch") }
 
         # Base files
         if test_pid == true
           it { should contain_file('/usr/lib/tmpfiles.d/elasticsearch.conf') }
         end
 
-	# file removal from package
-	it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
-	it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
+        # file removal from package
+        it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
+        it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
       end
 
       context 'package installation' do

--- a/spec/defines/010_elasticsearch_service_init_spec.rb
+++ b/spec/defines/010_elasticsearch_service_init_spec.rb
@@ -38,7 +38,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
   context "unmanaged" do
       let :params do {
         :ensure => 'present',
-	:status => 'unmanaged'
+        :status => 'unmanaged'
       } end
 
     it { should contain_elasticsearch__service__init('es-01') }
@@ -52,8 +52,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
     context "Set via file" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+        :status => 'enabled',
+        :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
       } end
 
       it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -62,8 +62,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
     context "Set via hash" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+        :status => 'enabled',
+        :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
       } end
 
       it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -75,8 +75,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
       context "Set via file" do
         let :params do {
           :ensure => 'present',
-	  :status => 'enabled',
-	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+          :status => 'enabled',
+          :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
         } end
 
         it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }
@@ -85,8 +85,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
       context "Set via hash" do
         let :params do {
           :ensure => 'present',
-  	  :status => 'enabled',
-  	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+          :status => 'enabled',
+          :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
         } end
 
         it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }
@@ -102,8 +102,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
     context "Via template" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
       } end
 
       it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -114,8 +114,8 @@ describe 'elasticsearch::service::init', :type => 'define' do
 
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
       } end
 
       it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -55,8 +55,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
     context "Set via file" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+        :status => 'enabled',
+        :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
       } end
 
       it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -65,8 +65,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
     context "Set via hash" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+        :status => 'enabled',
+        :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
       } end
 
       it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :before => 'Service[elasticsearch-instance-es-01]') }
@@ -78,8 +78,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       context "Set via file" do
         let :params do {
           :ensure => 'present',
-	  :status => 'enabled',
-	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+          :status => 'enabled',
+          :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
         } end
 
         it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -88,8 +88,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       context "Set via hash" do
         let :params do {
           :ensure => 'present',
-  	  :status => 'enabled',
-  	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+          :status => 'enabled',
+          :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
         } end
 
         it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
@@ -105,8 +105,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
     context "Via template" do
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
       } end
 
       it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[elasticsearch-instance-es-01]') }
@@ -117,8 +117,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
       let :params do {
         :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
       } end
 
       it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }

--- a/spec/fixtures/hiera/hieradata/singletemplate.yaml
+++ b/spec/fixtures/hiera/hieradata/singletemplate.yaml
@@ -1,0 +1,46 @@
+---
+elasticsearch::instances:
+  es-01:
+    config:
+      node.name: es-01
+elasticsearch::templates:
+  foo:
+    content:
+      mappings:
+        _default_:
+          _all:
+            enabled: true
+          dynamic_templates:
+          - string_fields:
+              mapping:
+                fields:
+                  raw:
+                    ignore_above: 256
+                    index: not_analyzed
+                    type: string
+                  '{name}':
+                    index: analyzed
+                    omit_norms: true
+                    type: string
+                type: multi_field
+              match: '*'
+              match_mapping_type: string
+          properties:
+            '@version':
+              index: not_analyzed
+              type: string
+            geoip:
+              dynamic: true
+              path: full
+              properties:
+                location:
+                  type: geo_point
+              type: object
+      settings:
+        analysis:
+          analyzer:
+            default:
+              stopwords: _none_
+              type: standard
+        index.refresh_interval: 5s
+      template: logstash-*

--- a/spec/spec_acceptance_common.rb
+++ b/spec/spec_acceptance_common.rb
@@ -106,41 +106,41 @@
     "settings" : {
       "index.refresh_interval" : "5s",
       "analysis" : {
-	"analyzer" : {
-	  "default" : {
-	    "type" : "standard",
-	    "stopwords" : "_none_"
-	  }
-	}
+        "analyzer" : {
+          "default" : {
+            "type" : "standard",
+            "stopwords" : "_none_"
+          }
+        }
       }
     },
     "mappings" : {
       "_default_" : {
-	 "_all" : {"enabled" : true},
-	 "dynamic_templates" : [ {
-	   "string_fields" : {
-	     "match" : "*",
-	     "match_mapping_type" : "string",
-	     "mapping" : {
-	       "type" : "multi_field",
-		 "fields" : {
-		   "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true },
-		   "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
-		 }
-	     }
-	   }
-	 } ],
-	 "properties" : {
-	   "@version": { "type": "string", "index": "not_analyzed" },
-	   "geoip"  : {
-	     "type" : "object",
-	       "dynamic": true,
-	       "path": "full",
-	       "properties" : {
-		 "location" : { "type" : "geo_point" }
-	       }
-	   }
-	 }
+         "_all" : {"enabled" : true},
+         "dynamic_templates" : [ {
+           "string_fields" : {
+             "match" : "*",
+             "match_mapping_type" : "string",
+             "mapping" : {
+               "type" : "multi_field",
+                 "fields" : {
+                   "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true },
+                   "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
+                 }
+             }
+           }
+         } ],
+         "properties" : {
+           "@version": { "type": "string", "index": "not_analyzed" },
+           "geoip"  : {
+             "type" : "object",
+               "dynamic": true,
+               "path": "full",
+               "properties" : {
+                 "location" : { "type" : "geo_point" }
+               }
+           }
+         }
       }
     }
   }'
@@ -149,41 +149,41 @@
     "settings" : {
       "index.refresh_interval" : "5s",
       "analysis" : {
-	"analyzer" : {
-	  "default" : {
-	    "type" : "standard",
-	    "stopwords" : "_none_"
-	  }
-	}
+        "analyzer" : {
+          "default" : {
+            "type" : "standard",
+            "stopwords" : "_none_"
+          }
+        }
       }
     },
     "mappings" : {
       "_default_" : {
-	 "_all" : {"enabled" : true},
-	 "dynamic_templates" : [ {
-	   "string_fields" : {
-	     "match" : "*",
-	     "match_mapping_type" : "string",
-	     "mapping" : {
-	       "type" : "multi_field",
-		 "fields" : {
-		   "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true },
-		   "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
-		 }
-	     }
-	   }
-	 } ],
-	 "properties" : {
-	   "@version": { "type": "string", "index": "not_analyzed" },
-	   "geoip"  : {
-	     "type" : "object",
-	       "dynamic": true,
-	       "path": "full",
-	       "properties" : {
-		 "location" : { "type" : "geo_point" }
-	       }
-	   }
-	 }
+         "_all" : {"enabled" : true},
+         "dynamic_templates" : [ {
+           "string_fields" : {
+             "match" : "*",
+             "match_mapping_type" : "string",
+             "mapping" : {
+               "type" : "multi_field",
+                 "fields" : {
+                   "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true },
+                   "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
+                 }
+             }
+           }
+         } ],
+         "properties" : {
+           "@version": { "type": "string", "index": "not_analyzed" },
+           "geoip"  : {
+             "type" : "object",
+               "dynamic": true,
+               "path": "full",
+               "properties" : {
+                 "location" : { "type" : "geo_point" }
+               }
+           }
+         }
       }
     }
   }'

--- a/templates/etc/init.d/elasticsearch.Debian.erb
+++ b/templates/etc/init.d/elasticsearch.Debian.erb
@@ -3,7 +3,7 @@
 # /etc/init.d/elasticsearch-<%= @name %> -- startup script for Elasticsearch
 #
 # Written by Miquel van Smoorenburg <miquels@cistron.nl>.
-# Modified for Debian GNU/Linux	by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+# Modified for Debian GNU/Linux by Ian Murdock <imurdock@gnu.ai.mit.edu>.
 # Modified for Tomcat by Stefan Gybas <sgybas@debian.org>.
 # Modified for Tomcat6 by Thierry Carrez <thierry.carrez@ubuntu.com>.
 # Additional improvements by Jason Brittain <jason.brittain@mulesoft.com>.
@@ -25,15 +25,15 @@ DESC="Elasticsearch Server <%= @name %>"
 DEFAULT=/etc/default/$NAME
 
 if [ `id -u` -ne 0 ]; then
-	echo "You need root privileges to run this script"
-	exit 1
+    echo "You need root privileges to run this script"
+    exit 1
 fi
 
 
 . /lib/lsb/init-functions
 
 if [ -r /etc/default/rcS ]; then
-	. /etc/default/rcS
+    . /etc/default/rcS
 fi
 
 
@@ -98,7 +98,7 @@ MAX_MAP_COUNT=262144
 
 # overwrite settings from default file
 if [ -f "$DEFAULT" ]; then
-	. "$DEFAULT"
+    . "$DEFAULT"
 fi
 
 # Define other required variables
@@ -118,90 +118,90 @@ export ES_GC_LOG_FILE
 test -x $DAEMON || exit 0
 
 checkJava() {
-	if [ -x "$JAVA_HOME/bin/java" ]; then
-		JAVA="$JAVA_HOME/bin/java"
-	else
-		JAVA=`which java`
-	fi
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA=`which java`
+    fi
 
-	if [ ! -x "$JAVA" ]; then
-		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-		exit 1
-	fi
+    if [ ! -x "$JAVA" ]; then
+        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+        exit 1
+    fi
 }
 
 case "$1" in
   start)
-	checkJava
+    checkJava
 
-	if [ -n "$MAX_LOCKED_MEMORY" -a -z "$ES_HEAP_SIZE" ]; then
-		log_failure_msg "MAX_LOCKED_MEMORY is set - ES_HEAP_SIZE must also be set"
-		exit 1
-	fi
+    if [ -n "$MAX_LOCKED_MEMORY" -a -z "$ES_HEAP_SIZE" ]; then
+        log_failure_msg "MAX_LOCKED_MEMORY is set - ES_HEAP_SIZE must also be set"
+        exit 1
+    fi
 
-	log_daemon_msg "Starting $DESC"
+    log_daemon_msg "Starting $DESC"
 
-	pid=`pidofproc -p $PID_FILE elasticsearch`
-	if [ -n "$pid" ] ; then
-		log_begin_msg "Already running."
-		log_end_msg 0
-		exit 0
-	fi
+    pid=`pidofproc -p $PID_FILE elasticsearch`
+    if [ -n "$pid" ] ; then
+        log_begin_msg "Already running."
+        log_end_msg 0
+        exit 0
+    fi
 
-	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
-	touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
+    # Prepare environment
+    mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
+    touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
 
-	if [ -n "$MAX_OPEN_FILES" ]; then
-		ulimit -n $MAX_OPEN_FILES
-	fi
+    if [ -n "$MAX_OPEN_FILES" ]; then
+        ulimit -n $MAX_OPEN_FILES
+    fi
 
-	if [ -n "$MAX_LOCKED_MEMORY" ]; then
-		ulimit -l $MAX_LOCKED_MEMORY
-	fi
+    if [ -n "$MAX_LOCKED_MEMORY" ]; then
+        ulimit -l $MAX_LOCKED_MEMORY
+    fi
 
-	if [ -n "$MAX_MAP_COUNT" ]; then
-		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
-	fi
+    if [ -n "$MAX_MAP_COUNT" ]; then
+        sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+    fi
 
-	# Start Daemon
-	start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
-	log_end_msg $?
-	;;
+    # Start Daemon
+    start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+    log_end_msg $?
+    ;;
   stop)
-	log_daemon_msg "Stopping $DESC"
+    log_daemon_msg "Stopping $DESC"
 
-	if [ -f "$PID_FILE" ]; then
-		start-stop-daemon --stop --pidfile "$PID_FILE" \
-			--user "$ES_USER" \
-			--retry=TERM/20/KILL/5 >/dev/null
-		if [ $? -eq 1 ]; then
-			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
-		elif [ $? -eq 3 ]; then
-			PID="`cat $PID_FILE`"
-			log_failure_msg "Failed to stop $DESC (pid $PID)"
-			exit 1
-		fi
-		rm -f "$PID_FILE"
-	else
-		log_progress_msg "(not running)"
-	fi
-	log_end_msg 0
-	;;
+    if [ -f "$PID_FILE" ]; then
+        start-stop-daemon --stop --pidfile "$PID_FILE" \
+            --user "$ES_USER" \
+            --retry=TERM/20/KILL/5 >/dev/null
+        if [ $? -eq 1 ]; then
+            log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+        elif [ $? -eq 3 ]; then
+            PID="`cat $PID_FILE`"
+            log_failure_msg "Failed to stop $DESC (pid $PID)"
+            exit 1
+        fi
+        rm -f "$PID_FILE"
+    else
+        log_progress_msg "(not running)"
+    fi
+    log_end_msg 0
+    ;;
   status)
-	status_of_proc -p $PID_FILE elasticsearch elasticsearch && exit 0 || exit $?
+    status_of_proc -p $PID_FILE elasticsearch elasticsearch && exit 0 || exit $?
     ;;
   restart|force-reload)
-	if [ -f "$PID_FILE" ]; then
-		$0 stop
-		sleep 1
-	fi
-	$0 start
-	;;
+    if [ -f "$PID_FILE" ]; then
+        $0 stop
+        sleep 1
+    fi
+    $0 start
+    ;;
   *)
-	log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
-	exit 1
-	;;
+    log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
+    exit 1
+    ;;
 esac
 
 exit 0


### PR DESCRIPTION
Allow use of elasticsearch::templates inside hiera:

``` YAML

---
elasticsearch::templates :
    templatename :
        content :
            template: "*"
            settings:
                number_of_replicas: 0
```
