### PR TITLE
Remove plugin dir when the package changes

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -167,8 +167,15 @@ class elasticsearch::package {
   if ($elasticsearch::package_provider == 'package') {
 
     package { $elasticsearch::package_name:
-      ensure   => $package_ensure,
+      ensure => $package_ensure,
+      notify => Exec['remove_plugin_dir'],
     }
+
+    exec { 'remove_plugin_dir':
+      refreshonly => true,
+      command     => "rm -rf ${elasticsearch::plugindir}",
+    }
+
 
   } else {
     fail("\"${elasticsearch::package_provider}\" is not supported")

--- a/spec/acceptance/021_es2x_spec.rb
+++ b/spec/acceptance/021_es2x_spec.rb
@@ -169,6 +169,8 @@ describe "elasticsearch 2x:" do
         pp = "class { 'elasticsearch': config => { 'node.name' => 'elasticsearch001', 'cluster.name' => '#{test_settings['cluster_name']}' }, manage_repo => true, repo_version => '#{test_settings['repo_version2x']}', java_install => true, version => '2.0.0' }
               elasticsearch::instance { 'es-01': config => { 'node.name' => 'elasticsearch001', 'http.port' => '#{test_settings['port_a']}' } }
               elasticsearch::plugin{'cloud-aws': instances => 'es-01' }
+              elasticsearch::plugin{'marvel-agent': instances => 'es-01' }
+              elasticsearch::plugin{'license': instances => 'es-01' }
         "
 
         # Run it twice and test for idempotency
@@ -192,6 +194,8 @@ describe "elasticsearch 2x:" do
         pp = "class { 'elasticsearch': config => { 'node.name' => 'elasticsearch001', 'cluster.name' => '#{test_settings['cluster_name']}' }, manage_repo => true, repo_version => '#{test_settings['repo_version2x']}', java_install => true, version => '2.0.1' }
               elasticsearch::instance { 'es-01': config => { 'node.name' => 'elasticsearch001', 'http.port' => '#{test_settings['port_a']}' } }
               elasticsearch::plugin{'cloud-aws': instances => 'es-01' }
+              elasticsearch::plugin{'marvel-agent': instances => 'es-01' }
+              elasticsearch::plugin{'license': instances => 'es-01' }
         "
 
         # Run it twice and test for idempotency

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -62,9 +62,10 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/scripts') }
         it { should contain_file('/usr/share/elasticsearch') }
         it { should contain_file('/usr/share/elasticsearch/lib') }
-        # it { should contain_file('/usr/share/elasticsearch/plugins') }
         it { should contain_file('/usr/share/elasticsearch/bin').with(:mode => '0755') }
 	it { should contain_augeas("#{defaults_path}/elasticsearch") }
+
+        it { should contain_exec('remove_plugin_dir') }
 
         # Base files
         if test_pid == true


### PR DESCRIPTION
For plugins we need to remove them all before we can install new ones.
This is a temporary solution until something better comes up.