### PR TITLE
Add batch flag and install_options param to plugin

### DIFF
--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -77,11 +77,18 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
     commands
   end
 
+  def install_options
+    return @resource[:install_options].join(' ') if @resource[:install_options].is_a?(Array)
+    return @resource[:install_options]
+  end
+
   def create
     es_version
     commands = []
     commands << @resource[:proxy_args].split(' ') if @resource[:proxy_args]
+    commands << install_options if @resource[:install_options]
     commands << 'install'
+    commands << '--batch' if is22x?
     commands << install1x if is1x?
     commands << install2x if is2x?
     debug("Commands: #{commands.inspect}")
@@ -136,6 +143,11 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
   def is2x?
     (Puppet::Util::Package.versioncmp(@es_version, '2.0.0') >= 0) && (Puppet::Util::Package.versioncmp(@es_version, '3.0.0') < 0)
   end
+
+  def is22x?
+    (Puppet::Util::Package.versioncmp(@es_version, '2.2.0') >= 0) && (Puppet::Util::Package.versioncmp(@es_version, '3.0.0') < 0)
+  end
+
 
   def plugin_version(plugin_name)
     vendor, plugin, version = plugin_name.split('/')

--- a/lib/puppet/type/elasticsearch_plugin.rb
+++ b/lib/puppet/type/elasticsearch_plugin.rb
@@ -28,4 +28,8 @@ Puppet::Type.newtype(:elasticsearch_plugin) do
     defaultto '/usr/share/elasticsearch/plugins'
   end
 
+  newparam(:install_options) do
+    desc 'Installation options'
+  end
+
 end

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -38,6 +38,7 @@ class elasticsearch::package {
   if $elasticsearch::ensure == 'present' {
 
     Package[$elasticsearch::package_name] ~> Elasticsearch::Service <| |>
+    Package[$elasticsearch::package_name] ~> Exec['remove_plugin_dir']
 
     # Create directory to place the package file
     $package_dir = $elasticsearch::package_dir
@@ -169,7 +170,6 @@ class elasticsearch::package {
 
     package { $elasticsearch::package_name:
       ensure => $package_ensure,
-      notify => Exec['remove_plugin_dir'],
     }
 
     exec { 'remove_plugin_dir':

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -68,13 +68,14 @@
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
 define elasticsearch::plugin(
-    $instances,
-    $module_dir  = undef,
-    $ensure      = 'present',
-    $url         = undef,
-    $source      = undef,
-    $proxy_host  = undef,
-    $proxy_port  = undef,
+  $instances,
+  $module_dir      = undef,
+  $ensure          = 'present',
+  $url             = undef,
+  $source          = undef,
+  $proxy_host      = undef,
+  $proxy_port      = undef,
+  $install_options = undef
 ) {
 
   include elasticsearch
@@ -127,12 +128,13 @@ define elasticsearch::plugin(
     'installed', 'present': {
 
       elasticsearch_plugin { $name:
-        ensure     => 'present',
-        source     => $file_source,
-        url        => $url,
-        proxy_args => $proxy,
-        plugin_dir => $::elasticsearch::plugindir,
-        notify     => $notify_service,
+        ensure          => 'present',
+        source          => $file_source,
+        url             => $url,
+        proxy_args      => $proxy,
+        plugin_dir      => $::elasticsearch::plugindir,
+        install_options => $install_options,
+        notify          => $notify_service,
       }
 
     }

--- a/spec/acceptance/integration001.rb
+++ b/spec/acceptance/integration001.rb
@@ -97,7 +97,9 @@ describe "Integration testing" do
       it 'should run successfully' do
         pp = "class { 'elasticsearch': config => { 'cluster.name' => '#{test_settings['cluster_name']}'}, java_install => true, package_url => '#{test_settings['snapshot_package']}' }
               elasticsearch::instance { 'es-01': config => { 'node.name' => 'elasticsearch001', 'http.port' => '#{test_settings['port_a']}' } }
-              elasticsearch::plugin{'lmenezes/elasticsearch-kopf': instances => 'es-01' }
+              elasticsearch::plugin{'license': instances => 'es-01' }
+              elasticsearch::plugin{'watcher': instances => 'es-01' }
+              elasticsearch::plugin{'marvel-agent': instances => 'es-01' }
              "
 
         # Run it twice and test for idempotency
@@ -120,11 +122,11 @@ describe "Integration testing" do
       end
 
       it 'make sure the directory exists' do
-        shell('ls /usr/share/elasticsearch/plugins/kopf/', {:acceptable_exit_codes => 0})
+        shell('ls /usr/share/elasticsearch/plugins/license/', {:acceptable_exit_codes => 0})
       end
 
       it 'make sure elasticsearch reports it as existing' do
-        curl_with_retries('validated plugin as installed', default, "http://localhost:#{test_settings['port_a']}/_nodes/?plugin | grep kopf", 0)
+        curl_with_retries('validated plugin as installed', default, "http://localhost:#{test_settings['port_a']}/_nodes/?plugin | grep license", 0)
       end
 
     end


### PR DESCRIPTION
The batch flag is required for ES 2.2.x with watcher

The install_options param allows to pass on extra options to the plugin
installer