### PR TITLE
Fix integration testing

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,12 +59,6 @@ class elasticsearch::config {
       ensure  => 'directory',
     }
 
-    file { "${elasticsearch::params::homedir}/bin":
-      ensure  => 'directory',
-      recurse => true,
-      mode    => '0755',
-    }
-
     file { $elasticsearch::datadir:
       ensure  => 'directory',
     }

--- a/spec/acceptance/integration001.rb
+++ b/spec/acceptance/integration001.rb
@@ -97,10 +97,8 @@ describe "Integration testing" do
       it 'should run successfully' do
         pp = "class { 'elasticsearch': config => { 'cluster.name' => '#{test_settings['cluster_name']}'}, java_install => true, package_url => '#{test_settings['snapshot_package']}' }
               elasticsearch::instance { 'es-01': config => { 'node.name' => 'elasticsearch001', 'http.port' => '#{test_settings['port_a']}' } }
-              elasticsearch::plugin{'license': instances => 'es-01' }
-              elasticsearch::plugin{'watcher': instances => 'es-01' }
-              elasticsearch::plugin{'marvel-agent': instances => 'es-01' }
              "
+        test_settings['plugin_list'].each { |plugin| pp.concat("elasticsearch::plugin{'#{plugin}': instances => 'es-01' }") }
 
         # Run it twice and test for idempotency
         apply_manifest(pp, :catch_failures => true)

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -62,7 +62,6 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/scripts') }
         it { should contain_file('/usr/share/elasticsearch') }
         it { should contain_file('/usr/share/elasticsearch/lib') }
-        it { should contain_file('/usr/share/elasticsearch/bin').with(:mode => '0755') }
 	it { should contain_augeas("#{defaults_path}/elasticsearch") }
 
         it { should contain_exec('remove_plugin_dir') }

--- a/spec/spec_acceptance_integration.rb
+++ b/spec/spec_acceptance_integration.rb
@@ -30,3 +30,16 @@ def get_url
   return url
 
 end
+
+def plugin_list
+
+  es1_list = [ 'elasticsearch/marvel/latest', 'elasticsearch/license/latest', 'elasticsearch/watcher/latest' ]
+  es2_list = [ 'marvel-agent', 'license', 'watcher' ]
+
+  es_version = ENV['ES_VERSION']
+  if es_version =~ /^2/
+    return es2_list
+  else
+    return es1_list
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -65,6 +65,7 @@ hosts.each do |host|
 
     url = get_url
     RSpec.configuration.test_settings['snapshot_package'] = url.gsub('$EXT$', ext)
+    RSpec.configuration.test_settings['plugin_list'] = plugin_list
 
   else
 


### PR DESCRIPTION
Plugin names changed between 1.x and 2.x so need to make it dynamic
In an earlier commit the commerical plugins were added to test those