### PR TITLE
Issue_580  Stop package_dl_timeout interfering with global resource defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@
 #
 # [*package_dl_timeout*]
 #   For http,https and ftp downloads you can set howlong the exec resource may take.
-#   Defaults to: 600 seconds
+#   Defaults to: undef (Puppet's default of 300 or a resource default will be used).
 #
 # [*proxy_url*]
 #   For http and https downloads you can set a proxy server to use

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -118,12 +118,17 @@ class elasticsearch::package {
           exec { 'download_package_elasticsearch':
             command     => "${elasticsearch::params::download_tool} ${pkg_source} ${elasticsearch::package_url} 2> /dev/null",
             creates     => $pkg_source,
-            environment => $exec_environment,
             timeout     => $elasticsearch::package_dl_timeout,
             require     => File[$package_dir],
             before      => $before,
           }
 
+          # We do this to allow the flexibility to use an Exec timeout globally via a resource default.
+          if $elasticsearch::package_dl_timeout {
+            Exec['download_package_elasticsearch'] {
+              timeout => $elasticsearch::package_dl_timeout,
+            }
+          }
         }
         'file': {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,9 +48,6 @@ class elasticsearch::params {
 
   $purge_package_dir = false
 
-  # package download timeout
-  $package_dl_timeout = 600 # 300 seconds is default of puppet
-
   $default_logging_level = 'INFO'
 
   $logging_defaults = {


### PR DESCRIPTION
If you're happy with this contribution, I'll make the same change in the logstash and logstash forwarder modules and any others that have the same issue.