### PR TITLE
Add puppetlabs-java to requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This module has been tested against all versions of ES 1.x and 2.x
 * [ceritsc/yum](https://forge.puppetlabs.com/ceritsc/yum) For yum version lock.
 * [richardc/datacat](https://forge.puppetlabs.com/richardc/datacat)
 * [Augeas](http://augeas.net/)
+* [puppetlabs-java](https://forge.puppetlabs.com/puppetlabs/java) for Java installation (optional).
 
 #### Repository management
 When using the repository management you will need the following dependency modules:


### PR DESCRIPTION
We should probably put the puppetlabs-java module in the requirements section of the README.

I've not added it to metadata.json as it's optional.

Inspired by https://github.com/elastic/puppet-elasticsearch/issues/586