### PR TITLE
Other attempt to call Facter to find osfamily

### DIFF
--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
   desc "A provider for the resource type `elasticsearch_plugin`,
         which handles plugin installation"
 
-  os = Facter['osfamily'].value
+  os = Facter.value('osfamily')
   if os == 'OpenBSD'
     commands :plugin => '/usr/local/elasticsearch/bin/plugin'
     commands :es => '/usr/local/elasticsearch/bin/elasticsearch'
@@ -117,7 +117,7 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
     es_save = ENV['ES_INCLUDE']
     java_save = ENV['JAVA_HOME']
 
-    os = Facter['osfamily'].value
+    os = Facter.value('osfamily')
     if os == 'OpenBSD'
       ENV['JAVA_HOME'] = javapathhelper('-h', 'elasticsearch').chomp
       ENV['ES_INCLUDE'] = '/etc/elasticsearch/elasticsearch.in.sh'


### PR DESCRIPTION
in provider/elasticsearch_plugin/plugin.rb

this is to fix the issue @benlangfeld reported here:
https://github.com/elastic/puppet-elasticsearch/commit/cc1e6b961047ba899f153abe30bdef8d8b2d2f6d#commitcomment-16365111

using his suggested fix, and at least does also work for me on OpenBSD.