### PR TITLE
Changed repo_key_id in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -240,7 +240,7 @@ class elasticsearch(
   $java_package          = undef,
   $manage_repo           = false,
   $repo_version          = undef,
-  $repo_key_id           = 'D88E42B4',
+  $repo_key_id           = '46095ACC8548582C1A2699A9D27D666CD88E42B4',
   $repo_key_source       = 'http://packages.elastic.co/GPG-KEY-elasticsearch',
   $logging_file          = undef,
   $logging_config        = undef,


### PR DESCRIPTION
Changed default repo_key_id value by fingerprint value to avoid puppet warnings like:
'/Apt_key[Add key: D88E42B4 from Apt::Source elasticsearch]
The id should be a full fingerprint (40 characters), see README.'