### PR TITLE
Add nss-lookup target to CentOS 7 unit

### DIFF
--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -1,6 +1,8 @@
 [Unit]
 Description=Starts and stops a single elasticsearch instance on this system
 Documentation=http://www.elasticsearch.org
+Wants=nss-lookup.target
+After=nss-lookup.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
We found a bug while rebooting our ElasticSearch data nodes in a CentOS 7 machine. The service starts but it keeps logging the following error:

```
[2016-03-16 09:58:46,764][WARN ][transport.netty          ] [vmd32dgz1] exception caught on transport layer [[id: 0x09aec994]], closing connection
java.nio.channels.UnresolvedAddressException
  at sun.nio.ch.Net.checkAddress(Net.java:101)
  at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:622)
  at org.elasticsearch.common.netty.channel.socket.nio.NioClientSocketPipelineSink.connect(NioClientSocketPipelineSink.java:108)
  at org.elasticsearch.common.netty.channel.socket.nio.NioClientSocketPipelineSink.eventSunk(NioClientSocketPipelineSink.java:70)
  at org.elasticsearch.common.netty.channel.DefaultChannelPipeline.sendDownstream(DefaultChannelPipeline.java:574)
  at org.elasticsearch.common.netty.channel.Channels.connect(Channels.java:634)
  at org.elasticsearch.common.netty.channel.AbstractChannel.connect(AbstractChannel.java:216)
  at org.elasticsearch.common.netty.bootstrap.ClientBootstrap.connect(ClientBootstrap.java:229)
  at org.elasticsearch.common.netty.bootstrap.ClientBootstrap.connect(ClientBootstrap.java:182)
  at org.elasticsearch.transport.netty.NettyTransport.connectToChannelsLight(NettyTransport.java:787)
  at org.elasticsearch.transport.netty.NettyTransport.connectToNode(NettyTransport.java:754)
  at org.elasticsearch.transport.netty.NettyTransport.connectToNodeLight(NettyTransport.java:726)
  at org.elasticsearch.transport.TransportService.connectToNodeLight(TransportService.java:220)
  at org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing$3.run(UnicastZenPing.java:373)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  at java.lang.Thread.run(Thread.java:745)
```

Restarting the service solves the issue. After checking some ElasticSearch tickets I found out that the problem seems to be related to the host/network name resolution.

There are some tickets related to this:
  - https://github.com/elastic/elasticsearch/pull/11256
  - https://github.com/elastic/elasticsearch/issues/16412 

I am no expert but adding the nss-lookup.target on the elasticsearch systemd unit fixes the issue for us, since we are telling the service to wait for the network to be ready.