### PR TITLE
Overhaul Puppet Enterprise Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,13 @@ matrix:
   allow_failures:
     - env: DISTRO=opensuse-13-x64
     - env: DISTRO=centos-6-x64
+    - env: DISTRO=centos-6-x64 PE=true
+    - env: DISTRO=ubuntu-server-1204-x64 PE=true
+    - env: DISTRO=ubuntu-server-1404-x64 PE=true
 
 install:
   - bundle install --path .vendor
   - bundle exec rake spec_prep
+  - bundle exec rake artifacts:prep
 script:
   - make test-$TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,15 @@ env:
     - TEST_SUITE=intake
     - TEST_SUITE=integration
     - DISTRO=centos-6-x64
+    - DISTRO=centos-6-x64 PE=true
     - DISTRO=centos-7-x64
+    - DISTRO=centos-7-x64 PE=true
     - DISTRO=debian-7-x64
     - DISTRO=debian-8-x64
     - DISTRO=ubuntu-server-1204-x64
+    - DISTRO=ubuntu-server-1204-x64 PE=true
     - DISTRO=ubuntu-server-1404-x64
+    - DISTRO=ubuntu-server-1404-x64 PE=true
     - DISTRO=opensuse-13-x64
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DISTRO ?= debian-8-x64
+DISTRO ?= ubuntu-server-1404-x64
 
 .vendor:
 	bundle install --path .vendor

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ PE_VER ?= 3.8.0
 
 .PHONY: fixtures
 fixtures: .vendor
-	bundle exec rake spec_prep
+	bundle exec rake artifacts:prep
 
 .PHONY: clean
 clean:
 	bundle exec rake spec_clean
+	bundle exec rake artifacts:clean
 	rm -rf .bundle .vendor
 
 .PHONY: test-intake

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 DISTRO ?= ubuntu-server-1404-x64
+PE ?= false
+PE_VER ?= 3.8.0
 
 .vendor:
 	bundle install --path .vendor
@@ -17,11 +19,25 @@ test-intake: test-docs test-rspec
 
 .PHONY: test-acceptance
 test-acceptance: .vendor fixtures
-	BEAKER_set=$(DISTRO) bundle exec rspec --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter spec/acceptance/*_spec.rb
+	BEAKER_PE_DIR=spec/fixtures/artifacts \
+		BEAKER_PE_VER=$(PE_VER) \
+		BEAKER_IS_PE=$(PE) \
+		BEAKER_set=$(DISTRO) \
+		bundle exec rspec \
+			--require ci/reporter/rspec \
+			--format CI::Reporter::RSpecFormatter \
+			spec/acceptance/*_spec.rb
 
 .PHONY: test-integration
 test-integration: .vendor fixtures
-	BEAKER_set=$(DISTRO) bundle exec rspec --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter spec/acceptance/integration001.rb
+	BEAKER_PE_DIR=spec/fixtures/artifacts \
+		BEAKER_PE_VER=$(PE_VER) \
+		BEAKER_IS_PE=$(PE) \
+		BEAKER_set=$(DISTRO) \
+		bundle exec rspec \
+			--require ci/reporter/rspec \
+			--format CI::Reporter::RSpecFormatter \
+			spec/acceptance/integration001.rb
 
 .PHONY: test-docs
 test-docs: .vendor
@@ -31,4 +47,5 @@ test-docs: .vendor
 test-rspec: .vendor
 	bundle exec rake lint
 	bundle exec rake validate
-	bundle exec rake spec SPEC_OPTS='--format documentation --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter'
+	bundle exec rake spec \
+		SPEC_OPTS='--format documentation --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter'

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,10 @@ exclude_paths = [
   "spec/**/*",
 ]
 
+pe_version = ENV['BEAKER_PE_VER']
+pe_version ||= '3.8.0'
+pe_baseurl = "https://s3.amazonaws.com/pe-builds/released/#{pe_version}"
+
 require 'puppet-doc-lint/rake_task'
 PuppetDocLint.configuration.ignore_paths = exclude_paths
 
@@ -32,13 +36,40 @@ end
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 
+
 artifacts = {
   'https://github.com/lmenezes/elasticsearch-kopf/archive/v2.1.1.zip' => 'elasticsearch-kopf.zip',
   'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.3.1.deb' => 'elasticsearch-1.3.1.deb',
   'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.0.deb' => 'elasticsearch-1.1.0.deb',
   'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.3.1.noarch.rpm' => 'elasticsearch-1.3.1.noarch.rpm',
   'https://github.com/lukas-vlcek/bigdesk/zipball/v2.4.0' => 'elasticsearch-bigdesk.zip',
-}.each { |_, fn| fn.replace "spec/fixtures/artifacts/#{fn}" }
+}
+
+{
+    :el => {
+        :arch     => "x86_64",
+        :versions => [6, 7],
+    },
+    :sles => {
+        :arch     => "x86_64",
+        :versions => [11, 12],
+    },
+    :ubuntu => {
+        :arch     => "amd64",
+        :versions => ["12.04", "14.04"],
+    },
+    :debian => {
+        :arch     => "amd64",
+        :versions => [7],
+    },
+}.each do |distro, metadata|
+    metadata[:versions].each do |version|
+        file = "puppet-enterprise-#{pe_version}-#{distro}-#{version}-#{metadata[:arch]}.tar.gz"
+        artifacts[[pe_baseurl, file].join('/')] = file
+    end
+end
+
+artifacts.each { |_, fn| fn.replace "spec/fixtures/artifacts/#{fn}" }
 
 Rake::Task['spec_prep'].enhance do
   artifacts.each do |url, fp|

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -12,4 +12,5 @@ HOSTS:
     docker_image_commands:
       - yum install -y wget
 CONFIG:
+  log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -10,7 +10,7 @@ HOSTS:
     docker_cmd: ["/sbin/init"]
     docker_preserve_image: true
     docker_image_commands:
-      - yum install -y wget
+      - yum install -y wget which cronie
       - mkdir -p /etc/selinux/targeted/contexts/
       - echo '<busconfig><selinux></selinux></busconfig>' > /etc/selinux/targeted/contexts/dbus_contexts
 CONFIG:

--- a/spec/acceptance/nodesets/debian-7-x64.yml
+++ b/spec/acceptance/nodesets/debian-7-x64.yml
@@ -10,6 +10,6 @@ HOSTS:
     docker_cmd: ["/sbin/init"]
     docker_preserve_image: true
     docker_image_commands:
-      - apt-get install -yq wget
+      - apt-get install -yq wget libssl-dev
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/opensuse-13-x64.yml
+++ b/spec/acceptance/nodesets/opensuse-13-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
       - database
       - dashboard
-    platform: sles-13-x64
+    platform: sles-13-x86_64
     image: opensuse:13.2
     hypervisor: docker
     docker_cmd: ["/bin/systemd"]

--- a/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
@@ -9,5 +9,8 @@ HOSTS:
     hypervisor: docker
     docker_cmd: ["/sbin/init"]
     docker_preserve_image: true
+    docker_image_commands:
+      - apt-get install -yq libssl-dev
+      - ln -sf /sbin/initctl.distrib /sbin/initctl
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
@@ -13,4 +13,5 @@ HOSTS:
       - apt-get install -yq libssl-dev
       - ln -sf /sbin/initctl.distrib /sbin/initctl
 CONFIG:
+  log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -4,9 +4,13 @@ HOSTS:
       - master
       - database
       - dashboard
-    platform: ubuntu-14.04-x64
+    platform: ubuntu-14.04-amd64
     image: ubuntu:14.04
     hypervisor: docker
+    docker_cmd: ["/sbin/init"]
     docker_preserve_image: true
+    docker_image_commands:
+      - apt-get install -yq libssl-dev
+      - ln -sf /sbin/initctl.distrib /sbin/initctl
 CONFIG:
   type: foss


### PR DESCRIPTION
This is some fairly self-explanatory code that pulls in necessary artifacts for puppet enterprise testing. The Travis config outlines how to run these - I've disabled a few that timeout, but in most cases setting `PE=true` in the environment properly runs and tests against puppet enterprise.