### PR TITLE
Fix Opensuse 12 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
     - DISTRO=opensuse-13-x64
 matrix:
   allow_failures:
-    - env: DISTRO=opensuse-13-x64
     - env: DISTRO=centos-6-x64
     - env: DISTRO=centos-6-x64 PE=true
     - env: DISTRO=ubuntu-server-1204-x64 PE=true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,7 +104,7 @@ class elasticsearch::config {
     file { '/etc/init.d/elasticsearch':
       ensure => 'absent',
     }
-    file { '/lib/systemd/system/elasticsearch.service':
+    file { "${elasticsearch::params::systemd_root}/elasticsearch.service":
       ensure => 'absent',
     }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,8 +104,10 @@ class elasticsearch::config {
     file { '/etc/init.d/elasticsearch':
       ensure => 'absent',
     }
-    file { "${elasticsearch::params::systemd_root}/elasticsearch.service":
-      ensure => 'absent',
+    if $elasticsearch::params::systemd_service_path {
+      file { "${elasticsearch::params::systemd_service_path}/elasticsearch.service":
+        ensure => 'absent',
+      }
     }
 
     $new_init_defaults = { 'CONF_DIR' => $elasticsearch::configdir }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -161,8 +161,10 @@ class elasticsearch::package {
       Package {
         provider  => 'rpm',
       }
+      $package_ensure = 'absent'
+    } else {
+      $package_ensure = 'purged'
     }
-    $package_ensure = 'purged'
 
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,12 +128,6 @@ class elasticsearch::params {
     }
   }
 
-  if $::operatingsystem == 'OpenSuSE' and versioncmp($::operatingsystemmajrelease, '13') >= 0 {
-    $systemd_root = '/usr/lib/systemd/system'
-  } else {
-    $systemd_root = '/lib/systemd/system'
-  }
-
   # packages
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {
@@ -170,8 +164,9 @@ class elasticsearch::params {
       $pid_dir            = '/var/run/elasticsearch'
 
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
+        $init_template        = 'elasticsearch.systemd.erb'
+        $service_providers    = 'systemd'
+        $systemd_service_path = '/lib/systemd/system'
       } else {
         $init_template     = 'elasticsearch.RedHat.erb'
         $service_providers = 'init'
@@ -195,9 +190,10 @@ class elasticsearch::params {
       $service_pattern    = $service_name
       $defaults_location  = '/etc/default'
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
-        $pid_dir           = '/var/run/elasticsearch'
+        $init_template        = 'elasticsearch.systemd.erb'
+        $service_providers    = 'systemd'
+        $systemd_service_path = '/lib/systemd/system'
+        $pid_dir              = '/var/run/elasticsearch'
       } else {
         $init_template     = 'elasticsearch.Debian.erb'
         $service_providers = [ 'init' ]
@@ -212,9 +208,10 @@ class elasticsearch::params {
       $defaults_location  = '/etc/default'
 
       if versioncmp($::operatingsystemmajrelease, '15') >= 0 {
-        $init_template     = 'elasticsearch.systemd.erb'
-        $service_providers = 'systemd'
-        $pid_dir           = '/var/run/elasticsearch'
+        $init_template        = 'elasticsearch.systemd.erb'
+        $service_providers    = 'systemd'
+        $systemd_service_path = '/lib/systemd/system'
+        $pid_dir              = '/var/run/elasticsearch'
       } else {
         $init_template     = 'elasticsearch.Debian.erb'
         $service_providers = [ 'init' ]
@@ -231,14 +228,19 @@ class elasticsearch::params {
       $pid_dir            = false
     }
     'OpenSuSE': {
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $service_providers  = 'systemd'
-      $defaults_location  = '/etc/sysconfig'
-      $init_template      = 'elasticsearch.systemd.erb'
-      $pid_dir            = '/var/run/elasticsearch'
+      $service_name          = 'elasticsearch'
+      $service_hasrestart    = true
+      $service_hasstatus     = true
+      $service_pattern       = $service_name
+      $service_providers     = 'systemd'
+      $defaults_location     = '/etc/sysconfig'
+      $init_template         = 'elasticsearch.systemd.erb'
+      $pid_dir               = '/var/run/elasticsearch'
+      if $::operatingsystem == 'OpenSuSE' and versioncmp($::operatingsystemmajrelease, '12') <= 0 {
+        $systemd_service_path = '/lib/systemd/system'
+      } else {
+        $systemd_service_path = '/usr/lib/systemd/system'
+      }
     }
     'Gentoo': {
       $service_name       = 'elasticsearch'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,6 +128,12 @@ class elasticsearch::params {
     }
   }
 
+  if $::operatingsystem == 'OpenSuSE' and versioncmp($::operatingsystemmajrelease, '13') >= 0 {
+    $systemd_root = '/usr/lib/systemd/system'
+  } else {
+    $systemd_root = '/lib/systemd/system'
+  }
+
   # packages
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -68,6 +68,9 @@ class elasticsearch::repo {
         gpgcheck    => 1,
         gpgkey      => $::elasticsearch::repo_key_source,
         type        => 'yum',
+      } ~>
+      exec { 'zypper refresh elasticsearch':
+        refreshonly => true,
       }
     }
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -69,7 +69,8 @@ class elasticsearch::repo {
         gpgkey      => $::elasticsearch::repo_key_source,
         type        => 'yum',
       } ~>
-      exec { 'zypper refresh elasticsearch':
+      exec { 'elasticsearch_zypper_refresh_elasticsearch':
+        command     => 'zypper refresh elasticsearch',
         refreshonly => true,
       }
     }

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -163,7 +163,7 @@ define elasticsearch::service::systemd(
         $memlock = undef
       }
 
-      file { "${elasticsearch::params::systemd_root}/elasticsearch-${name}.service":
+      file { "${elasticsearch::params::systemd_service_path}/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),
         before  => Service["elasticsearch-instance-${name}"],
@@ -176,7 +176,7 @@ define elasticsearch::service::systemd(
 
   } else {
 
-    file { "${elasticsearch::params::systemd_root}/elasticsearch-${name}.service":
+    file { "${elasticsearch::params::systemd_service_path}/elasticsearch-${name}.service":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"],

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -163,7 +163,7 @@ define elasticsearch::service::systemd(
         $memlock = undef
       }
 
-      file { "/lib/systemd/system/elasticsearch-${name}.service":
+      file { "${elasticsearch::params::systemd_root}/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),
         before  => Service["elasticsearch-instance-${name}"],
@@ -176,7 +176,7 @@ define elasticsearch::service::systemd(
 
   } else {
 
-    file { "/lib/systemd/system/elasticsearch-${name}.service":
+    file { "${elasticsearch::params::systemd_root}/elasticsearch-${name}.service":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"],

--- a/spec/acceptance/014_hiera_spec.rb
+++ b/spec/acceptance/014_hiera_spec.rb
@@ -175,6 +175,9 @@ describe "Hiera tests" do
       it { should_not be_running }
     end
 
+    after do
+      write_hiera_config([])
+    end
   end
 
 

--- a/spec/acceptance/nodesets/opensuse-13-x64.yml
+++ b/spec/acceptance/nodesets/opensuse-13-x64.yml
@@ -10,7 +10,7 @@ HOSTS:
     docker_cmd: ["/bin/systemd"]
     docker_preserve_image: true
     docker_image_commands:
-      - zypper install -y dbus-1 rubygems which augeas augeas-lenses
+      - zypper install -y dbus-1 rubygems which augeas augeas-lenses wget
       - zypper install -y -t pattern devel_basis || true
       - mkdir -p /etc/selinux/targeted/contexts/
       - echo '<busconfig><selinux></selinux></busconfig>' > /etc/selinux/targeted/contexts/dbus_contexts

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -38,6 +38,13 @@ describe 'elasticsearch', :type => 'class' do
         let(:version_add) { '-1' }
       end
 
+      if facts[:operatingsystem] == 'OpenSuSE' and
+        facts[:operatingsystemrelease].to_i >= 13
+        let(:systemd_path) { '/usr/lib/systemd/system' }
+      else
+        let(:systemd_path) { '/lib/systemd/system' }
+      end
+
       let(:facts) do
         facts.merge({ 'scenario' => '', 'common' => '' })
       end
@@ -62,7 +69,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/usr/share/elasticsearch/scripts') }
         it { should contain_file('/usr/share/elasticsearch') }
         it { should contain_file('/usr/share/elasticsearch/lib') }
-	it { should contain_augeas("#{defaults_path}/elasticsearch") }
+        it { should contain_augeas("#{defaults_path}/elasticsearch") }
 
         it { should contain_exec('remove_plugin_dir') }
 
@@ -71,11 +78,11 @@ describe 'elasticsearch', :type => 'class' do
           it { should contain_file('/usr/lib/tmpfiles.d/elasticsearch.conf') }
         end
 
-	# file removal from package
-	it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
-	it { should contain_file('/lib/systemd/system/elasticsearch.service').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
-	it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
+        # file removal from package
+        it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
+        it { should contain_file("#{systemd_path}/elasticsearch.service").with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
       end
 
       context 'package installation' do
@@ -244,7 +251,12 @@ describe 'elasticsearch', :type => 'class' do
           })
         }
 
-        it { should contain_package('elasticsearch').with(:ensure => 'purged') }
+        case facts[:osfamily]
+        when 'Suse'
+          it { should contain_package('elasticsearch').with(:ensure => 'absent') }
+        else
+          it { should contain_package('elasticsearch').with(:ensure => 'purged') }
+        end
         it { should contain_file('/usr/share/elasticsearch/plugins').with(:ensure => 'absent') }
 
       end

--- a/spec/classes/005_elasticsearch_repo_spec.rb
+++ b/spec/classes/005_elasticsearch_repo_spec.rb
@@ -58,6 +58,7 @@ describe 'elasticsearch', :type => 'class' do
         context 'has zypper repo parts' do
           it { should contain_exec('elasticsearch_suse_import_gpg').with(:command => 'rpmkeys --import http://packages.elastic.co/GPG-KEY-elasticsearch') }
           it { should contain_zypprepo('elasticsearch').with(:baseurl => 'http://packages.elastic.co/elasticsearch/1.3/centos') }
+          it { should contain_exec('elasticsearch_zypper_refresh_elasticsearch') }
         end
       end
 

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -2,129 +2,144 @@ require 'spec_helper'
 
 describe 'elasticsearch::service::systemd', :type => 'define' do
 
-  let :facts do {
-    :operatingsystem => 'OpenSuSE',
-    :kernel => 'Linux',
-    :osfamily => 'Suse',
-    :operatingsystemmajrelease => '11',
-    :scenario => '',
-    :common => ''
-  } end
+  on_supported_os({
+    :hardwaremodels => ['x86_64'],
+    :supported_os => [
+      {
+        'operatingsystem' => 'OpenSuSE',
+        'operatingsystemrelease' => ['12', '13'],
+      },
+      {
+        'operatingsystem' => 'CentOS',
+        'operatingsystemrelease' => ['6', '7'],
+      }
+    ]
+  }).each do |os, facts|
 
-  let(:title) { 'es-01' }
-  let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}}' }
+    context "on #{os}" do
 
-  context "Setup service" do
+      let(:facts) { facts }
+      let(:title) { 'es-01' }
+      let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}}' }
 
-    let :params do {
-      :ensure => 'present',
-      :status => 'enabled'
-    } end
-
-    it { should contain_elasticsearch__service__systemd('es-01') }
-    it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
-    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'running', :enable => true, :provider => 'systemd') }
-  end
-
-  context "Remove service" do
-
-    let :params do {
-      :ensure => 'absent'
-    } end
-
-    it { should contain_elasticsearch__service__systemd('es-01') }
-    it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
-    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'stopped', :enable => false, :provider => 'systemd') }
-  end
-
-  context "unmanaged" do
-    let :params do {
-      :ensure => 'present',
-      :status => 'unmanaged'
-    } end
-
-
-    it { should contain_elasticsearch__service__systemd('es-01') }
-    it { should contain_service('elasticsearch-instance-es-01').with(:enable => false) }
-    it { should contain_augeas('defaults_es-01') }
-
-  end
-
-  context "Defaults file" do
-
-    context "Set via file" do
-      let :params do {
-        :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults_file => 'puppet:///path/to/initdefaultsfile'
-      } end
-
-      it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :before => 'Service[elasticsearch-instance-es-01]') }
-    end
-
-    context "Set via hash" do
-      let :params do {
-        :ensure => 'present',
-	:status => 'enabled',
-	:init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
-      } end
-
-      it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :before => 'Service[elasticsearch-instance-es-01]') }
-    end
-
-    context "No restart when 'restart_on_change' is false" do
-      let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}, restart_on_change => false } ' }
-
-      context "Set via file" do
-        let :params do {
-          :ensure => 'present',
-	  :status => 'enabled',
-	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
-        } end
-
-        it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+      if facts[:operatingsystem] == 'OpenSuSE' and
+        facts[:operatingsystemrelease].to_i >= 13
+        let(:systemd_path) { '/usr/lib/systemd/system' }
+      else
+        let(:systemd_path) { '/lib/systemd/system' }
       end
 
-      context "Set via hash" do
+      context "Setup service" do
+
         let :params do {
           :ensure => 'present',
-  	  :status => 'enabled',
-  	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+          :status => 'enabled'
         } end
 
-        it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+        it { should contain_elasticsearch__service__systemd('es-01') }
+        it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
+        it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'running', :enable => true, :provider => 'systemd') }
       end
 
-    end
+      context "Remove service" do
 
-  end
+        let :params do {
+          :ensure => 'absent'
+        } end
 
-  context "Init file" do
-    let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }} } ' }
+        it { should contain_elasticsearch__service__systemd('es-01') }
+        it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
+        it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'stopped', :enable => false, :provider => 'systemd') }
+      end
 
-    context "Via template" do
-      let :params do {
-        :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
-      } end
+      context "unmanaged" do
+        let :params do {
+          :ensure => 'present',
+          :status => 'unmanaged'
+        } end
 
-      it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[elasticsearch-instance-es-01]') }
-    end
 
-    context "No restart when 'restart_on_change' is false" do
-      let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}, restart_on_change => false } ' }
+        it { should contain_elasticsearch__service__systemd('es-01') }
+        it { should contain_service('elasticsearch-instance-es-01').with(:enable => false) }
+        it { should contain_augeas('defaults_es-01') }
 
-      let :params do {
-        :ensure => 'present',
-	:status => 'enabled',
-	:init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
-      } end
+      end
 
-      it { should contain_file('/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+      context "Defaults file" do
 
-    end
+        context "Set via file" do
+          let :params do {
+            :ensure => 'present',
+        :status => 'enabled',
+        :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+          } end
 
-  end
+          it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :before => 'Service[elasticsearch-instance-es-01]') }
+        end
 
-end
+        context "Set via hash" do
+          let :params do {
+            :ensure => 'present',
+        :status => 'enabled',
+        :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+          } end
+
+          it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :before => 'Service[elasticsearch-instance-es-01]') }
+        end
+
+        context "No restart when 'restart_on_change' is false" do
+          let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}, restart_on_change => false } ' }
+
+          context "Set via file" do
+            let :params do {
+              :ensure => 'present',
+          :status => 'enabled',
+          :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
+            } end
+
+            it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+          end
+
+          context "Set via hash" do
+            let :params do {
+              :ensure => 'present',
+          :status => 'enabled',
+          :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
+            } end
+
+            it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+          end
+
+        end
+
+      end
+
+      context "Init file" do
+        let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }} } ' }
+
+        context "Via template" do
+          let :params do {
+            :ensure => 'present',
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
+          } end
+
+          it { should contain_file("#{systemd_path}/elasticsearch-es-01.service").with(:before => 'Service[elasticsearch-instance-es-01]') }
+        end
+
+        context "No restart when 'restart_on_change' is false" do
+          let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}, restart_on_change => false } ' }
+
+          let :params do {
+            :ensure => 'present',
+        :status => 'enabled',
+        :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
+          } end
+
+          it { should contain_file("#{systemd_path}/elasticsearch-es-01.service").with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+
+        end
+      end
+    end # of context on os
+  end # of on_supported_os
+end # of describe elasticsearch::service::systemd

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -11,7 +11,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
       },
       {
         'operatingsystem' => 'CentOS',
-        'operatingsystemrelease' => ['6', '7'],
+        'operatingsystemrelease' => ['7'],
       }
     ]
   }).each do |os, facts|
@@ -24,9 +24,9 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
       if facts[:operatingsystem] == 'OpenSuSE' and
         facts[:operatingsystemrelease].to_i >= 13
-        let(:systemd_path) { '/usr/lib/systemd/system' }
+        let(:systemd_service_path) { '/usr/lib/systemd/system' }
       else
-        let(:systemd_path) { '/lib/systemd/system' }
+        let(:systemd_service_path) { '/lib/systemd/system' }
       end
 
       context "Setup service" do
@@ -124,7 +124,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
         :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
           } end
 
-          it { should contain_file("#{systemd_path}/elasticsearch-es-01.service").with(:before => 'Service[elasticsearch-instance-es-01]') }
+          it { should contain_file("#{systemd_service_path}/elasticsearch-es-01.service").with(:before => 'Service[elasticsearch-instance-es-01]') }
         end
 
         context "No restart when 'restart_on_change' is false" do
@@ -136,7 +136,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
         :init_template => 'elasticsearch/etc/init.d/elasticsearch.systemd.erb'
           } end
 
-          it { should contain_file("#{systemd_path}/elasticsearch-es-01.service").with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
+          it { should contain_file("#{systemd_service_path}/elasticsearch-es-01.service").with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
 
         end
       end


### PR DESCRIPTION
This adds opensuse to the list of distros run through CI and fixes some lingering problems along the way (package purging, some tests that didn't do proper cleanup.)

It also borrows from some community work in preparation to accept some SLES pull requests by defining systemd library paths that may differ across distributions.