### PR TITLE
Test for and fix strict variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DISTRO ?= ubuntu-server-1404-x64
 PE ?= false
+STRICT_VARIABLES ?= yes
 
 ifeq ($(PE), true)
 	PE_VER ?= 3.8.0
@@ -43,4 +44,5 @@ test-docs: .vendor
 test-rspec: .vendor
 	bundle exec rake lint
 	bundle exec rake validate
-	bundle exec rake spec_verbose
+	STRICT_VARIABLES=$(STRICT_VARIABLES) \
+		bundle exec rake spec_verbose

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -113,6 +113,8 @@ class elasticsearch::package {
               "http_proxy=${elasticsearch::proxy_url}",
               "https_proxy=${elasticsearch::proxy_url}",
             ]
+          } else {
+            $exec_environment = []
           }
 
           exec { 'download_package_elasticsearch':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -168,20 +168,22 @@ class elasticsearch::params {
         $service_providers    = 'systemd'
         $systemd_service_path = '/lib/systemd/system'
       } else {
-        $init_template     = 'elasticsearch.RedHat.erb'
-        $service_providers = 'init'
+        $init_template        = 'elasticsearch.RedHat.erb'
+        $service_providers    = 'init'
+        $systemd_service_path = undef
       }
 
     }
     'Amazon': {
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $defaults_location  = '/etc/sysconfig'
-      $pid_dir            = '/var/run/elasticsearch'
-      $init_template      = 'elasticsearch.RedHat.erb'
-      $service_providers  = 'init'
+      $service_name         = 'elasticsearch'
+      $service_hasrestart   = true
+      $service_hasstatus    = true
+      $service_pattern      = $service_name
+      $defaults_location    = '/etc/sysconfig'
+      $pid_dir              = '/var/run/elasticsearch'
+      $init_template        = 'elasticsearch.RedHat.erb'
+      $service_providers    = 'init'
+      $systemd_service_path = undef
     }
     'Debian': {
       $service_name       = 'elasticsearch'
@@ -195,9 +197,10 @@ class elasticsearch::params {
         $systemd_service_path = '/lib/systemd/system'
         $pid_dir              = '/var/run/elasticsearch'
       } else {
-        $init_template     = 'elasticsearch.Debian.erb'
-        $service_providers = [ 'init' ]
-        $pid_dir           = false
+        $init_template        = 'elasticsearch.Debian.erb'
+        $pid_dir              = false
+        $service_providers    = [ 'init' ]
+        $systemd_service_path = undef
       }
     }
     'Ubuntu': {
@@ -213,19 +216,21 @@ class elasticsearch::params {
         $systemd_service_path = '/lib/systemd/system'
         $pid_dir              = '/var/run/elasticsearch'
       } else {
-        $init_template     = 'elasticsearch.Debian.erb'
-        $service_providers = [ 'init' ]
-        $pid_dir           = false
+        $init_template        = 'elasticsearch.Debian.erb'
+        $pid_dir              = false
+        $service_providers    = [ 'init' ]
+        $systemd_service_path = undef
       }
     }
     'Darwin': {
-      $service_name       = 'FIXME/TODO'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $service_providers  = 'launchd'
-      $defaults_location  = false
-      $pid_dir            = false
+      $service_name         = 'FIXME/TODO'
+      $service_hasrestart   = true
+      $service_hasstatus    = true
+      $service_pattern      = $service_name
+      $service_providers    = 'launchd'
+      $systemd_service_path = undef
+      $defaults_location    = false
+      $pid_dir              = false
     }
     'OpenSuSE': {
       $service_name          = 'elasticsearch'
@@ -243,24 +248,26 @@ class elasticsearch::params {
       }
     }
     'Gentoo': {
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = $service_name
-      $service_providers  = 'openrc'
-      $defaults_location  = '/etc/conf.d'
-      $init_template      = 'elasticsearch.openrc.erb'
-      $pid_dir            = '/run/elasticsearch'
+      $service_name         = 'elasticsearch'
+      $service_hasrestart   = true
+      $service_hasstatus    = true
+      $service_pattern      = $service_name
+      $service_providers    = 'openrc'
+      $systemd_service_path = undef
+      $defaults_location    = '/etc/conf.d'
+      $init_template        = 'elasticsearch.openrc.erb'
+      $pid_dir              = '/run/elasticsearch'
     }
     'OpenBSD': {
-      $service_name       = 'elasticsearch'
-      $service_hasrestart = true
-      $service_hasstatus  = true
-      $service_pattern    = undef
-      $service_providers  = 'openbsd'
-      $defaults_location  = undef
-      $init_template      = 'elasticsearch.OpenBSD.erb'
-      $pid_dir            = '/var/run/elasticsearch'
+      $service_name         = 'elasticsearch'
+      $service_hasrestart   = true
+      $service_hasstatus    = true
+      $service_pattern      = undef
+      $service_providers    = 'openbsd'
+      $systemd_service_path = undef
+      $defaults_location    = undef
+      $init_template        = 'elasticsearch.OpenBSD.erb'
+      $pid_dir              = '/var/run/elasticsearch'
     }
     default: {
       fail("\"${module_name}\" provides no service parameters

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -124,7 +124,11 @@ define elasticsearch::plugin(
       before => Elasticsearch_plugin[$name],
     }
 
-  } elsif ($url != undef) {
+  } else {
+    $file_source = undef
+  }
+
+  if ($url != undef) {
     validate_string($url)
   }
 

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -18,7 +18,10 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
     context "on #{os}" do
 
-      let(:facts) { facts }
+      let(:facts) { facts.merge({
+          :scenario => '',
+          :common => ''
+      }) }
       let(:title) { 'es-01' }
       let(:pre_condition) { 'class {"elasticsearch": config => { "node" => {"name" => "test" }}}' }
 


### PR DESCRIPTION
Rspec testing with strict variables hasn't been enabled for a while, and there are a few spots where they've crept in. This PR adds testing for them across the board and fixes the places they've shown up.

Should fix #588, thanks to @simon77 and @jsnod for catching it.