### PR TITLE
Add matrix of Puppet Enterprise version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,19 @@ env:
   - DISTRO=centos-7-x64 PE=true PE_VER=3.7.2
   - DISTRO=centos-7-x64 PE=true PE_VER=2016.1.1
   - DISTRO=debian-7-x64
+  - DISTRO=debian-7-x64 PE=true
+  - DISTRO=debian-7-x64 PE=true PE_VER=3.7.2
+    # No 2016.x release for debian 7
   - DISTRO=debian-8-x64
   - DISTRO=ubuntu-server-1204-x64
   - DISTRO=ubuntu-server-1204-x64 PE=true
+  - DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=3.7.2
+  - DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=2016.1.1
   - DISTRO=ubuntu-server-1404-x64
   - DISTRO=ubuntu-server-1404-x64 PE=true
+  - DISTRO=ubuntu-server-1404-x64 PE=true PE_VER=3.7.2
+  - DISTRO=ubuntu-server-1404-x64 PE=true PE_VER=2016.1.1
   - DISTRO=opensuse-13-x64
-matrix:
-  allow_failures:
-  - env: DISTRO=ubuntu-server-1204-x64 PE=true
-  - env: DISTRO=ubuntu-server-1404-x64 PE=true
 install:
 - bundle install --path .vendor
 - bundle exec rake spec_prep

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ env:
   - TEST_SUITE=integration
   - DISTRO=centos-6-x64
   - DISTRO=centos-6-x64 PE=true
+  - DISTRO=centos-6-x64 PE=true PE_VER=3.7.2
+  - DISTRO=centos-6-x64 PE=true PE_VER=2016.1.1
   - DISTRO=centos-7-x64
   - DISTRO=centos-7-x64 PE=true
+  - DISTRO=centos-7-x64 PE=true PE_VER=3.7.2
+  - DISTRO=centos-7-x64 PE=true PE_VER=2016.1.1
   - DISTRO=debian-7-x64
   - DISTRO=debian-8-x64
   - DISTRO=ubuntu-server-1204-x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,13 @@ env:
   - DISTRO=centos-7-x64 PE=true PE_VER=2016.1.1
   - DISTRO=debian-7-x64
   - DISTRO=debian-7-x64 PE=true
-  - DISTRO=debian-7-x64 PE=true PE_VER=3.7.2
     # No 2016.x release for debian 7
   - DISTRO=debian-8-x64
   - DISTRO=ubuntu-server-1204-x64
   - DISTRO=ubuntu-server-1204-x64 PE=true
-  - DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=3.7.2
   - DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=2016.1.1
   - DISTRO=ubuntu-server-1404-x64
   - DISTRO=ubuntu-server-1404-x64 PE=true
-  - DISTRO=ubuntu-server-1404-x64 PE=true PE_VER=3.7.2
   - DISTRO=ubuntu-server-1404-x64 PE=true PE_VER=2016.1.1
   - DISTRO=opensuse-13-x64
 install:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'beaker'
 gem 'beaker-rspec'
 gem 'metadata-json-lint'
 gem 'rspec-puppet'
+gem 'specinfra', '>= 2.55'
 
 gem 'pry'
 gem 'docker-api', '~> 1.0'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 DISTRO ?= ubuntu-server-1404-x64
-PUPPET_VERSION ?= 3.8.6
 PE ?= false
 
 ifeq ($(PE), true)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DISTRO ?= ubuntu-server-1404-x64
 PE ?= false
 
 ifeq ($(PE), true)
-	PE_VER ?= 3.8.0
+	PE_VER ?= 3.8.3
 	BEAKER_PE_VER := $(PE_VER)
 	BEAKER_IS_PE := $(PE)
 	export BEAKER_PE_VER

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DISTRO ?= ubuntu-server-1404-x64
+PUPPET_VERSION ?= 3.8.6
 PE ?= false
 
 ifeq ($(PE), true)
@@ -9,7 +10,11 @@ ifeq ($(PE), true)
 	export BEAKER_IS_PE
 endif
 
-.vendor:
+.DEFAULT_GOAL := bundle
+
+.PHONY: bundle
+bundle:
+	bundle update || true
 	bundle install --path .vendor
 
 .PHONY: clean
@@ -22,13 +27,13 @@ clean:
 test-intake: test-docs test-rspec
 
 .PHONY: test-acceptance
-test-acceptance: .vendor
+test-acceptance: bundle
 	BEAKER_PE_DIR=spec/fixtures/artifacts \
 		BEAKER_set=$(DISTRO) \
 		bundle exec rake beaker:acceptance
 
 .PHONY: test-integration
-test-integration: .vendor
+test-integration: bundle
 	BEAKER_PE_DIR=spec/fixtures/artifacts \
 		BEAKER_PE_VER=$(PE_VER) \
 		BEAKER_IS_PE=$(PE) \
@@ -36,11 +41,11 @@ test-integration: .vendor
 		bundle exec rake beaker:integration
 
 .PHONY: test-docs
-test-docs: .vendor
+test-docs: bundle
 	bundle exec rake parse_doc
 
 .PHONY: test-rspec
-test-rspec: .vendor
+test-rspec: bundle
 	bundle exec rake lint
 	bundle exec rake validate
 	bundle exec rake spec_verbose

--- a/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
@@ -12,5 +12,7 @@ HOSTS:
     docker_image_commands:
       - apt-get install -yq libssl-dev
       - ln -sf /sbin/initctl.distrib /sbin/initctl
+      - locale-gen en_US en_US.UTF-8
+      - dpkg-reconfigure locales
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -12,5 +12,7 @@ HOSTS:
     docker_image_commands:
       - apt-get install -yq libssl-dev
       - ln -sf /sbin/initctl.distrib /sbin/initctl
+      - locale-gen en_US en_US.UTF-8
+      - dpkg-reconfigure locales
 CONFIG:
   type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'beaker-rspec'
 require 'pry'
 require 'securerandom'
+require 'thread'
 require_relative 'spec_acceptance_integration'
 
 def test_settings
@@ -17,7 +18,9 @@ hosts.each do |host|
 
   # Install Puppet
   if host.is_pe?
+    pe_progress = Thread.new { while sleep 5 ; print '.' ; end }
     install_pe
+    pe_progress.exit
   else
     install_puppet_on host, :default_action => 'gem_install'
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,7 +12,6 @@ RSpec.configure do |c|
 end
 
 files_dir = ENV['files_dir'] || './spec/fixtures/artifacts'
-puppet_version = ENV['PUPPET_VERSION'] || '3.8.6'
 
 hosts.each do |host|
 
@@ -20,10 +19,7 @@ hosts.each do |host|
   if host.is_pe?
     install_pe
   else
-    install_puppet_on host, {
-      :version        => puppet_version,
-      :default_action => 'gem_install',
-    }
+    install_puppet_on host, :default_action => 'gem_install'
 
     if fact('osfamily') == 'Suse'
       install_package host, 'augeas-devel libxml2-devel'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,6 +12,7 @@ RSpec.configure do |c|
 end
 
 files_dir = ENV['files_dir'] || './spec/fixtures/artifacts'
+puppet_version = ENV['PUPPET_VERSION'] || '3.8.6'
 
 hosts.each do |host|
 
@@ -19,7 +20,10 @@ hosts.each do |host|
   if host.is_pe?
     install_pe
   else
-    install_puppet_on host, :default_action => 'gem_install'
+    install_puppet_on host, {
+      :version        => puppet_version,
+      :default_action => 'gem_install',
+    }
 
     if fact('osfamily') == 'Suse'
       install_package host, 'augeas-devel libxml2-devel'


### PR DESCRIPTION
Adds a reasonable set of Puppet Enterprise versions to the test matrix (latest 2016.x, latest in the 3.8.x series, and one version prior.)