### PR TITLE
Closes #618

### DIFF
--- a/spec/acceptance/013_config_spec.rb
+++ b/spec/acceptance/013_config_spec.rb
@@ -41,7 +41,7 @@ describe "elasticsearch class:" do
       it { should contain 'master: true' }
       it { should contain 'data: false' }
       it { should contain "cluster:\n  name: #{test_settings['cluster_name']}" }
-      it { should contain 'rack: 46' }
+      its(:content) { should match /rack: \W*46\W*/ }
       it { should contain "index: \n  routing: \n    allocation: \n      exclude: \n             - tag2\n             - tag3\n      include: tag1" }
     end
 

--- a/spec/templates/001_elasticsearch.yml.erb_spec.rb
+++ b/spec/templates/001_elasticsearch.yml.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class String
   def config
-    "### MANAGED BY PUPPET ###\n---#{unindent}"
+    "### MANAGED BY PUPPET ###\n--- #{unindent}"
   end
 
   def unindent
@@ -35,8 +35,8 @@ describe 'elasticsearch.yml.erb' do
           ping: 
             unicast: 
               hosts: 
-                   - host1
-                   - host2
+                - host1
+                - host2
       node: 
         name: test
       path: 
@@ -70,8 +70,8 @@ describe 'elasticsearch.yml.erb' do
     expect(harness.run).to eq(%q{
       data: 
         path: 
-            - /mnt/sda1
-            - /mnt/sdb1
+          - /mnt/sda1
+          - /mnt/sdb1
       }.config)
   end
 
@@ -86,9 +86,46 @@ describe 'elasticsearch.yml.erb' do
     expect(harness.run).to eq(%q{
       shield: 
         http: 
-          ssl: true
+          ssl: "true"
           ssl.client: 
             auth: optional
+      }.config)
+  end
+
+  it 'should render correct array of hashes' do
+    harness.set(
+      '@data', {
+        'node.name' => 'test',
+        'path' => { 'data' => '/mnt/test' },
+        'discovery.zen.ping.unicast.hosts' => [
+          'host1', 'host2'
+        ],
+        'data' => [
+          { 'key' => 'some value 0',
+            'other_key' => 'some other value 0' },
+          { 'key' => 'some value 1',
+            'other_key' => 'some other value 1' },
+        ]
+      }
+    )
+
+    expect(harness.run).to eq(%q{
+      data: 
+        - key: "some value 0"
+          other_key: "some other value 0"
+        - key: "some value 1"
+          other_key: "some other value 1"
+      discovery: 
+        zen: 
+          ping: 
+            unicast: 
+              hosts: 
+                - host1
+                - host2
+      node: 
+        name: test
+      path: 
+        data: /mnt/test
       }.config)
   end
 end

--- a/spec/templates/001_elasticsearch.yml.erb_spec.rb
+++ b/spec/templates/001_elasticsearch.yml.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class String
   def config
-    "### MANAGED BY PUPPET ###\n--- #{unindent}"
+    "### MANAGED BY PUPPET ###\n---#{unindent}"
   end
 
   def unindent
@@ -30,16 +30,16 @@ describe 'elasticsearch.yml.erb' do
     )
 
     expect(harness.run).to eq(%q{
-      discovery: 
-        zen: 
-          ping: 
-            unicast: 
-              hosts: 
+      discovery:
+        zen:
+          ping:
+            unicast:
+              hosts:
                 - host1
                 - host2
-      node: 
+      node:
         name: test
-      path: 
+      path:
         data: /mnt/test
       }.config)
   end
@@ -53,7 +53,7 @@ describe 'elasticsearch.yml.erb' do
     )
 
     expect(harness.run).to eq(%q{
-      node: 
+      node:
         name: test
         rack: r1
       }.config)
@@ -68,8 +68,8 @@ describe 'elasticsearch.yml.erb' do
     )
 
     expect(harness.run).to eq(%q{
-      data: 
-        path: 
+      data:
+        path:
           - /mnt/sda1
           - /mnt/sdb1
       }.config)
@@ -84,10 +84,10 @@ describe 'elasticsearch.yml.erb' do
     )
 
     expect(harness.run).to eq(%q{
-      shield: 
-        http: 
+      shield:
+        http:
           ssl: "true"
-          ssl.client: 
+          ssl.client:
             auth: optional
       }.config)
   end
@@ -110,21 +110,21 @@ describe 'elasticsearch.yml.erb' do
     )
 
     expect(harness.run).to eq(%q{
-      data: 
+      data:
         - key: "some value 0"
           other_key: "some other value 0"
         - key: "some value 1"
           other_key: "some other value 1"
-      discovery: 
-        zen: 
-          ping: 
-            unicast: 
-              hosts: 
+      discovery:
+        zen:
+          ping:
+            unicast:
+              hosts:
                 - host1
                 - host2
-      node: 
+      node:
         name: test
-      path: 
+      path:
         data: /mnt/test
       }.config)
   end

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -76,17 +76,6 @@
     # Transform it into yaml
     @yml_string += sorted_hash.to_yaml
 
-    # Puppet < 4 uses ZAML, which has some deviations from Puppet 4 YAML implementation
-    unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0
-      @yml_string.gsub!(/^\s{2}/, '')
-      # Remove space character after colon
-      @yml_string.gsub!(/:\s$/, ':')
-      # Remove space character after ---
-      @yml_string.gsub!(/---\s$/, '---')
-      # Add new line at the end of yaml file
-      @yml_string += "\n"
-    end
-
   end
 
 -%>

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -76,9 +76,14 @@
     # Transform it into yaml
     @yml_string += sorted_hash.to_yaml
 
-    # Puppet < 4 uses ZAML, which prepends spaces in to_yaml
+    # Puppet < 4 uses ZAML, which has some deviations from Puppet 4 YAML implementation
     unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0
       @yml_string.gsub!(/^\s{2}/, '')
+      # Remove space character after colon
+      @yml_string.gsub!(/:\s$/, ':')
+      # Remove space character after ---
+      @yml_string.gsub!(/---\s$/, '---')
+      # Add new line at the end of yaml file
       @yml_string += "\n"
     end
 

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -1,27 +1,5 @@
 <%-
 
-  # Function to make a structured and sorted yaml representation out of a hash
-  def recursive_hash_to_yml_string(hash, depth=0)
-    spacer = ""
-    depth.times { spacer += "  "}
-    hash.keys.sort.each do |sorted_key|
-      @yml_string += spacer + sorted_key + ": "
-      if hash[sorted_key].is_a?(::Array)
-         keyspacer = ""
-         sorted_key.length.times { keyspacer += " " }
-         @yml_string += "\n"
-         hash[sorted_key].each do |item|
-           @yml_string += spacer + keyspacer + "- " + item +"\n"
-         end
-      elsif hash[sorted_key].is_a?(::Hash)
-        @yml_string += "\n"
-        recursive_hash_to_yml_string(hash[sorted_key], depth+1)
-      else
-        @yml_string += "#{hash[sorted_key].to_s}\n"
-      end
-    end
-  end
-
   # Function to transform shorted write up of the keys into full hash representation
   def transform(hash)
   return_vals = []
@@ -83,8 +61,6 @@
 
   if !@data.empty?
 
-    @yml_string += "---\n"
-
     ## Transform shorted keys into full write up
     transformed_config = transform(@data)
 
@@ -94,8 +70,17 @@
       tmphash = tmphash.deep_merge_with_array_values_concatenated(subhash)
     end
 
+    # Sort Hash
+    sorted_hash = Hash[tmphash.sort]
+
     # Transform it into yaml
-    recursive_hash_to_yml_string(tmphash)
+    @yml_string += sorted_hash.to_yaml
+
+    # Puppet < 4 uses ZAML, which prepends spaces in to_yaml
+    unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0
+      @yml_string.gsub!(/^\s{2}/, '')
+      @yml_string += "\n"
+    end
 
   end
 

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -1,4 +1,6 @@
 <%-
+  $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..","..","lib"))
+  require 'puppet/provider/elastic_yaml'
 
   # Function to transform shorted write up of the keys into full hash representation
   def transform(hash)
@@ -70,11 +72,13 @@
       tmphash = tmphash.deep_merge_with_array_values_concatenated(subhash)
     end
 
-    # Sort Hash
-    sorted_hash = Hash[tmphash.sort]
+    # Sort Hash and transform it into yaml
+    @yml_string += tmphash.extend(Puppet_X::Elastic::Hash).to_yaml
 
-    # Transform it into yaml
-    @yml_string += sorted_hash.to_yaml
+    # Puppet < 4 uses ZAML, which has some deviations from Puppet 4 YAML implementation
+    unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0
+      @yml_string.gsub!(/^\s{2}/, '')
+    end
 
   end
 


### PR DESCRIPTION
As part of your pull request, please review the following tasks:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass

Rspec tests for ERB templates pass for puppet 3.8.0 and puppet >=4.0.0.

Unfortunately have nothing to do with the rest of YAML implementation differences for Puppet 3 and 4 except this:
```ruby
    # Puppet < 4 uses ZAML, which has some deviations from Puppet 4 YAML implementation
    unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0
      @yml_string.gsub!(/^\s{2}/, '')
      # Remove space character after colon
      @yml_string.gsub!(/:\s$/, ':')
      # Remove space character after ---
      @yml_string.gsub!(/---\s$/, '---')
      # Add new line at the end of yaml file
      @yml_string += "\n"
    end
```
So updated rspec tests to handle this difference. Some of the tests are more demonstrative to show difference. Added YAML validation to rspec tests.

Maybe more tests, validation is required because this config is rather important.