### PR TITLE
Fix yaml-based provider hash ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,19 +425,21 @@ elasticsearch::shield::role { 'logstash':
   ],
   privileges => {
     'cluster' => 'manage_index_templates',
-    'indices' => {
+    'indices' => [{
       'names'      => ['logstash-*'],
       'privileges' => [
         'write',
         'delete',
         'create_index',
       ],
-    },
+    }],
   },
 }
 ```
 
-Note that if you'd like to keep the mappings file purged of entries not under Puppet's control, you should use the following `resources` declaration because mappings are a separate low-level type:
+**Note**: Observe the brackets around `indices` in the preceding role definition; which is an array of hashes per the format in Shield 2.3.x. Follow the documentation to determine the correct formatting for your version of Shield.
+
+If you'd like to keep the mappings file purged of entries not under Puppet's control, you should use the following `resources` declaration because mappings are a separate low-level type:
 
 ```puppet
 resources { 'elasticsearch_shield_role_mapping':

--- a/lib/puppet/provider/elastic_yaml.rb
+++ b/lib/puppet/provider/elastic_yaml.rb
@@ -1,5 +1,7 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
 require 'puppet/provider/parsedfile'
 require 'puppet/util/package'
+require 'puppet_x/elastic/hash'
 
 class Puppet::Provider::ElasticYaml < Puppet::Provider::ParsedFile
 
@@ -29,7 +31,7 @@ class Puppet::Provider::ElasticYaml < Puppet::Provider::ParsedFile
     end.inject({}) do |hash, record|
       # Flatten array of hashes into single hash
       hash.merge({ record['name'] => record.delete(@metadata.to_s) })
-    end.to_yaml
+    end.extend(Puppet_X::Elastic::Hash).to_yaml
 
     # Puppet < 4 uses ZAML, which prepends spaces in to_yaml ಠ_ಠ
     unless Puppet::Util::Package.versioncmp(Puppet.version, '4') >= 0

--- a/lib/puppet_x/elastic/hash.rb
+++ b/lib/puppet_x/elastic/hash.rb
@@ -1,0 +1,36 @@
+module Puppet_X
+  module Elastic
+    module Hash
+
+      # Upon extension, recurse into the hash to extend all nested
+      # hashes with the sorted each_pair method.
+      # Note that respond_to? is used here as there were weird
+      # problems with .class/.is_a?
+      def self.extended(base)
+        base.merge! base do |_, ov, nv|
+          if ov.respond_to? :each_pair
+            ov.extend Puppet_X::Elastic::Hash
+          elsif ov.is_a? Array
+            ov.map do |elem|
+              if elem.respond_to? :each_pair
+                elem.extend Puppet_X::Elastic::Hash
+              else
+                elem
+              end
+            end
+          else
+            ov
+          end
+        end
+      end
+
+      # Override each_pair with a method that yields key/values in
+      # sorted order.
+      def each_pair
+        keys.sort.each do |key|
+          yield key, self[key]
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/elastic/hash.rb
+++ b/lib/puppet_x/elastic/hash.rb
@@ -2,24 +2,56 @@ module Puppet_X
   module Elastic
     module Hash
 
-      # Upon extension, recurse into the hash to extend all nested
-      # hashes with the sorted each_pair method.
-      # Note that respond_to? is used here as there were weird
-      # problems with .class/.is_a?
+      # Upon extension, modify the hash appropriately to render
+      # sorted yaml dependent upon whichever way is supported for
+      # this version of Puppet/Ruby's yaml implementation.
       def self.extended(base)
-        base.merge! base do |_, ov, nv|
-          if ov.respond_to? :each_pair
-            ov.extend Puppet_X::Elastic::Hash
-          elsif ov.is_a? Array
-            ov.map do |elem|
-              if elem.respond_to? :each_pair
-                elem.extend Puppet_X::Elastic::Hash
-              else
-                elem
+
+        if RUBY_VERSION >= '1.9'
+          # We can sort the hash in Ruby >= 1.9 by recursively
+          # re-inserting key/values in sorted order. Native to_yaml will
+          # call .each and get sorted pairs back.
+          tmp = base.to_a.sort
+          base.clear
+          tmp.each do |key, val|
+            if val.is_a? base.class
+              val.extend Puppet_X::Elastic::Hash
+            elsif val.is_a? Array
+              val.map do |elem|
+                if elem.is_a? base.class
+                  elem.extend(Puppet_X::Elastic::Hash)
+                else
+                  elem
+                end
               end
             end
-          else
-            ov
+            base[key] = val
+          end
+        else
+          # Otherwise, recurse into the hash to extend all nested
+          # hashes with the sorted each_pair method.
+          #
+          # Ruby < 1.9 doesn't support any notion of sorted hashes,
+          # so we have to expressly monkey patch each_pair, which is
+          # called by ZAML (the yaml library used in Puppet < 4; Puppet
+          # >= 4 deprecates Ruby 1.8)
+          #
+          # Note that respond_to? is used here as there were weird
+          # problems with .class/.is_a?
+          base.merge! base do |_, ov, nv|
+            if ov.respond_to? :each_pair
+              ov.extend Puppet_X::Elastic::Hash
+            elsif ov.is_a? Array
+              ov.map do |elem|
+                if elem.respond_to? :each_pair
+                  elem.extend Puppet_X::Elastic::Hash
+                else
+                  elem
+                end
+              end
+            else
+              ov
+            end
           end
         end
       end

--- a/spec/unit/provider/elastic_yaml_spec.rb
+++ b/spec/unit/provider/elastic_yaml_spec.rb
@@ -1,0 +1,68 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),'..','..','lib'))
+
+require 'spec_helper'
+require 'puppet/provider/elastic_yaml'
+
+class String
+  def flattened
+    split("\n").reject(&:empty?).map(&:strip).join("\n").strip
+  end
+end
+
+describe Puppet::Provider::ElasticYaml do
+
+  subject do
+    described_class.tap do |o|
+      o.instance_eval { @metadata = :metadata }
+    end
+  end
+
+  let :unsorted_hash do
+    [{
+      :name => 'role',
+      :metadata => {
+        'zeta' => {
+          'zeta'  => 5,
+          'gamma' => 4,
+          'delta' => 3,
+          'beta'  => 2,
+          'alpha' => 1
+        },
+        'phi' => [{
+          'zeta'  => 3,
+          'gamma' => 2,
+          'alpha' => 1
+        }],
+        'beta'  => 'foobaz',
+        'gamma' => 1,
+        'alpha' => 'foobar'
+      }
+    }]
+  end
+
+  it { is_expected.to respond_to :to_file }
+
+  describe 'to_file' do
+    it 'returns sorted yaml' do
+      expect(described_class.to_file(unsorted_hash).flattened).to(
+        eq(%q{
+          ---
+          role:
+            alpha: foobar
+            beta: foobaz
+            gamma: 1
+            phi:
+              - alpha: 1
+                gamma: 2
+                zeta: 3
+            zeta:
+              alpha: 1
+              beta: 2
+              delta: 3
+              gamma: 4
+              zeta: 5
+        }.flattened)
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes #636.

Shield (at least as of 2.3.2) expects the list of indices applied to a role to be a list of hashes, but **requires** that `name` be the first key of that hash. For example, the following yaml works:

```yaml
admin:
  cluster: all
  indices:
    - names: "*"
      privileges:
        - all   
```

While the following fails to get parsed:

```yaml
admin:
  cluster: all
  indices:
    - privileges:
        - all
      names: "*"
```

Simply writing out the yaml with *ordered* keys is enough to resolve this, but ordering and hashes don't jive that well. This patch does some gymnastics to ensure that the hash is ordered when `to_yaml` is called in the parent provider for children providers like `elasticsearch_shield_role`.

The code is fairly self-explanatory [with comments 😅 ] and should work for all versions of Ruby and Puppet.

Also added some additional notes to the README to clarify how later versions of Shield roles expected to be formatted, and an explicit test to ensure all yaml using the elastic_yaml parent provider is ordered correctly.