### PR TITLE
Removed install_options

### DIFF
--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -86,19 +86,11 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
     commands
   end
 
-  def install_options
-    return @resource[:install_options].join(' ') if @resource[:install_options].is_a?(Array)
-    return @resource[:install_options]
-  end
-
   def create
     es_version
     commands = []
     commands << @resource[:proxy_args].split(' ') if @resource[:proxy_args]
-    commands << install_options if @resource[:install_options]
-    if install_options.nil? or not install_options.include? 'es.path.conf'
-      commands << "-Des.path.conf=#{homedir}"
-    end
+    commands << "-Des.path.conf=#{homedir}"
     commands << 'install'
     commands << '--batch' if is22x?
     commands << install1x if is1x?

--- a/lib/puppet/type/elasticsearch_plugin.rb
+++ b/lib/puppet/type/elasticsearch_plugin.rb
@@ -28,8 +28,4 @@ Puppet::Type.newtype(:elasticsearch_plugin) do
     defaultto '/usr/share/elasticsearch/plugins'
   end
 
-  newparam(:install_options) do
-    desc 'Installation options'
-  end
-
 end

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -50,9 +50,6 @@
 #   Specify all the instances related
 #   value type is string or array
 #
-# [*install_options*]
-#   Pass options to the plugin installer
-#
 # === Examples
 #
 # # From official repository
@@ -77,8 +74,7 @@ define elasticsearch::plugin(
   $url             = undef,
   $source          = undef,
   $proxy_host      = undef,
-  $proxy_port      = undef,
-  $install_options = undef
+  $proxy_port      = undef
 ) {
 
   include elasticsearch
@@ -136,13 +132,12 @@ define elasticsearch::plugin(
     'installed', 'present': {
 
       elasticsearch_plugin { $name:
-        ensure          => 'present',
-        source          => $file_source,
-        url             => $url,
-        proxy_args      => $proxy,
-        plugin_dir      => $::elasticsearch::plugindir,
-        install_options => $install_options,
-        notify          => $notify_service,
+        ensure     => 'present',
+        source     => $file_source,
+        url        => $url,
+        proxy_args => $proxy,
+        plugin_dir => $::elasticsearch::plugindir,
+        notify     => $notify_service,
       }
 
     }


### PR DESCRIPTION
install_options was causing all sorts of issues.  In lieu of fixing it, right now I've opted to remove it.  The behavior exhibited by the install_options parameter was inconsistent at best and upon looking at the (few) lines of code involving install_options, I couldn't determine a reason for it to sometimes report as an invalid parameter.

