### PR TITLE
Implement repo priority pinning for apt and yum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Features
 * The `elasticsearch::config` parameter now supports deep hiera merging.
+* Added the `elasticsearch::repo_priority` parameter to support apt and yum repository priority configuration.
 
 #### Bugfixes
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,10 @@
 # [*repo_version*]
 #   Our repositories are versioned per major version (0.90, 1.0) select here which version you want
 #
+# [*repo_priority*]
+#   Repository priority. yum and apt supported.
+#   Default: undef
+#
 # [*repo_key_id*]
 #   String.  The apt GPG key id
 #   Default: D88E42B4
@@ -300,6 +304,7 @@ class elasticsearch(
   $java_package           = undef,
   $manage_repo            = false,
   $repo_version           = undef,
+  $repo_priority          = undef,
   $repo_key_id            = 'D88E42B4',
   $repo_key_source        = 'http://packages.elastic.co/GPG-KEY-elasticsearch',
   $repo_proxy             = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -43,6 +43,7 @@ class elasticsearch::repo {
         key         => $::elasticsearch::repo_key_id,
         key_source  => $::elasticsearch::repo_key_source,
         include_src => false,
+        pin         => $elasticsearch::repo_priority,
       }
     }
     'RedHat', 'Linux': {
@@ -54,6 +55,7 @@ class elasticsearch::repo {
         gpgkey   => $::elasticsearch::repo_key_source,
         enabled  => 1,
         proxy    => $::elasticsearch::repo_proxy,
+        priority => $elasticsearch::repo_priority,
       } ~>
       exec { 'elasticsearch_yumrepo_yum_clean':
         command     => 'yum clean metadata expire-cache --disablerepo="*" --enablerepo="elasticsearch"',

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -346,6 +346,31 @@ describe 'elasticsearch', :type => 'class' do
         end
       end
 
+      context 'repository priority pinning' do
+
+        let :params do
+          default_params.merge({
+            :manage_repo => true,
+            :repo_priority => 10,
+            :repo_version => '2.x'
+          })
+        end
+
+        case facts[:osfamily]
+        when 'Debian'
+          context 'is supported' do
+            it { should contain_apt__source('elasticsearch').with(
+              :pin => 10
+            ) }
+          end
+        when 'RedHat'
+          context 'is supported' do
+            it { should contain_yumrepo('elasticsearch').with(
+              :priority => 10
+            ) }
+          end
+        end
+      end
 
       context "Running a a different user" do
 


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

---

Simple fix for #664. The necessary yum plugin for pinning isn't included here, as the user is expected to handle the plugin installation if necessary - this change just exposes the option to set it if needed.