### PR TITLE
Fix is vs. should values for _templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 #### Bugfixes
+* Fixed issues that caused templates to be incorrectly detected as out-of-sync and thus always changed on each puppet run.
 
 #### Changes
 * Updated repository gpg fingerprint key to long form to silence module warnings.

--- a/lib/puppet/provider/elasticsearch_template/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_template/ruby.rb
@@ -1,6 +1,10 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..","..",".."))
+
 require 'json'
 require 'net/http'
 require 'openssl'
+
+require 'puppet_x/elastic/deep_to_i'
 
 Puppet::Type.type(:elasticsearch_template).provide(:ruby) do
   desc <<-ENDHEREDOC
@@ -44,12 +48,13 @@ Puppet::Type.type(:elasticsearch_template).provide(:ruby) do
     req = Net::HTTP::Get.new uri.request_uri
 
     response = rest http, req, validate_tls, timeout, username, password
+
     if response.code.to_i == 200
       JSON.parse(response.body).map do |name, template|
         {
           :name => name,
           :ensure => :present,
-          :content => template,
+          :content => Puppet_X::Elastic::deep_to_i(template),
           :provider => :ruby
         }
       end

--- a/lib/puppet_x/elastic/deep_to_i.rb
+++ b/lib/puppet_x/elastic/deep_to_i.rb
@@ -1,0 +1,19 @@
+module Puppet_X
+  module Elastic
+    # This ugly hack is required due to the fact Puppet passes in the
+    # puppet-native hash with stringified numerics, which causes the
+    # decoded JSON from the Elasticsearch API to be seen as out-of-sync
+    # when the parsed template hash is compared against the puppet hash.
+    def self.deep_to_i obj
+      if obj.is_a? String and obj =~ /^[0-9]+$/
+        obj.to_i
+      elsif obj.is_a? Array
+        obj.map { |element| deep_to_i(element) }
+      elsif obj.is_a? Hash
+        obj.merge(obj) { |key, val| deep_to_i(val) }
+      else
+        obj
+      end
+    end
+  end # of Elastic
+end # of Puppet_X

--- a/spec/unit/provider/elasticsearch_template/ruby.rb
+++ b/spec/unit/provider/elasticsearch_template/ruby.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:elasticsearch_template).provider(:ruby) do
               "foobar2": {
                 "aliases": {},
                 "mappings": {},
-                "order": 2,
+                "order": "2",
                 "settings": {},
                 "template": "foobar2-*"
               }

--- a/spec/unit/type/elasticsearch_template_spec.rb
+++ b/spec/unit/type/elasticsearch_template_spec.rb
@@ -200,6 +200,26 @@ describe Puppet::Type.type(:elasticsearch_template) do
           'order' => 1
         )
       end
+
+      it 'should qualify settings' do
+        expect(described_class.new(
+          :name => resource_name,
+          :content => { 'settings' => {
+            'number_of_replicas' => '2',
+            'index' => { 'number_of_shards' => '3' }
+          } }
+        )[:content]).to eq({
+          'order' => 0,
+          'aliases' => {},
+          'mappings' => {},
+          'settings' => {
+            'index' => {
+              'number_of_replicas' => 2,
+              'number_of_shards' => 3
+            }
+          }
+        })
+      end
     end
   end # of describing when validing values
 end # of describe Puppet::Type


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

There are some cases in which template content doesn't sync up with user-specified template content:
- Elasticsearch's json numerics may not get parsed as numbers, so this PR ensures everything is fully parsed in that regard.
- Because users can specify index settings without the `index` settings key when defining templates, the `_template` API endpoint is disjoint from user-defined resources that opt to use the short form. This change forces the type to munge settings values to put them in the same form the API returns.
- If a user opts to simply define index settings without any mappings, the API will return an empty hash. This change provides a default value as well if it is not specified.
- Tests to verify all this works as expected.

Fixes #678.
