### PR TITLE
Fix Puppet 3.4.x/3.6 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 #### Bugfixes
+* Fixed a couple of cases that broke compatability with older versions of puppet (elasticsearch_template types on puppet versions prior to 3.6 and yumrepo parameters on puppet versions prior to 3.5.1)
 
 #### Changes
 * Updated repository gpg fingerprint key to long form to silence module warnings.

--- a/lib/puppet/type/elasticsearch_template.rb
+++ b/lib/puppet/type/elasticsearch_template.rb
@@ -162,7 +162,8 @@ Puppet::Type.newtype(:elasticsearch_template) do
         fail "Could not retrieve source %s" % self[:source]
       end
 
-      unless self.catalog.nil?
+      if not self.catalog.nil? and \
+          self.catalog.respond_to?(:environment_instance)
         tmp = Puppet::FileServing::Content.indirection.find(
           self[:source],
           :environment => self.catalog.environment_instance

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -47,8 +47,14 @@ class elasticsearch::repo {
       }
     }
     'RedHat', 'Linux': {
+      # Versions prior to 3.5.1 have issues with this param
+      # See: https://tickets.puppetlabs.com/browse/PUP-2163
+      if versioncmp($::puppetversion, '3.5.1') >= 0 {
+        Yumrepo['elasticsearch'] {
+          ensure => $elasticsearch::ensure,
+        }
+      }
       yumrepo { 'elasticsearch':
-        ensure   => $elasticsearch::ensure,
         descr    => 'elasticsearch repo',
         baseurl  => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/centos",
         gpgcheck => 1,


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

There are some specific cases that broke older puppet versions, this should resolve those issues with puppet <= 3.5.1 using manage_repo and puppet < 3.6 elasticsearch::template resources.

Fixes #673.