### PR TITLE
Fix es_instance_validator template configtimeout deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 #### Bugfixes
 
 #### Changes
+* Updated the elasticsearch_template type to return more helpful error output.
+* Updated the es_instance_conn_validator type to silence deprecation warnings in Puppet >= 4.
 
 #### Testing changes
 

--- a/lib/puppet/util/es_instance_validator.rb
+++ b/lib/puppet/util/es_instance_validator.rb
@@ -10,6 +10,13 @@ module Puppet
       def initialize(instance_server, instance_port)
         @instance_server = instance_server
         @instance_port   = instance_port
+
+        # Avoid deprecation warnings in Puppet versions < 4
+        if Facter.value(:puppetversion).split('.').first.to_i < 4
+          @timeout = Puppet[:configtimeout]
+        else
+          @timeout = Puppet[:http_connect_timeout]
+        end
       end
 
       # Utility method; attempts to make an https connection to the Elasticsearch instance.
@@ -18,7 +25,7 @@ module Puppet
       #
       # @return true if the connection is successful, false otherwise.
       def attempt_connection
-        Timeout::timeout(Puppet[:configtimeout]) do
+        Timeout::timeout(@timeout) do
           begin
             TCPSocket.new(@instance_server, @instance_port).close
             true


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Fixes #683 
