### PR TITLE
Enforce plugin directory permissions for outside access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 #### Bugfixes
+* Recursively enforce correct plugin directory mode to avoid Elasticsearch startup permissions errors.
 
 #### Changes
 * Updated the elasticsearch_template type to return more helpful error output.

--- a/lib/puppet/parser/functions/es_plugin_name.rb
+++ b/lib/puppet/parser/functions/es_plugin_name.rb
@@ -14,6 +14,9 @@ module Puppet::Parser::Functions
     For example, all the following return values are "plug":
 
         es_plugin_name('plug')
+        es_plugin_name('foo/plug')
+        es_plugin_name('foo/plug/1.0.0')
+        es_plugin_name('foo/elasticsearch-plug')
         es_plugin_name('foo/es-plug/1.3.2')
     ENDHEREDOC
 

--- a/lib/puppet/parser/functions/es_plugin_name.rb
+++ b/lib/puppet/parser/functions/es_plugin_name.rb
@@ -1,0 +1,30 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+
+require 'puppet_x/elastic/plugin_name'
+
+module Puppet::Parser::Functions
+  newfunction(
+    :es_plugin_name,
+    :type => :rvalue,
+    :doc => <<-'ENDHEREDOC') do |args|
+    Given a string, return the best guess at what the directory name
+    will be for the given plugin. Any arguments past the first will
+    be fallbacks (using the same logic) should the first fail.
+
+    For example, all the following return values are "plug":
+
+        es_plugin_name('plug')
+        es_plugin_name('foo/es-plug/1.3.2')
+    ENDHEREDOC
+
+    if args.length < 1
+      raise Puppet::ParseError,
+        'wrong number of arguments, at least one value required'
+    end
+
+    args.each do |arg|
+      next unless arg.is_a? String
+      return Puppet_X::Elastic::plugin_name arg
+    end
+  end
+end

--- a/lib/puppet/parser/functions/es_plugin_name.rb
+++ b/lib/puppet/parser/functions/es_plugin_name.rb
@@ -22,13 +22,15 @@ module Puppet::Parser::Functions
         'wrong number of arguments, at least one value required'
     end
 
-    args.each do |arg|
-      next unless arg.is_a? String
-      next if arg.empty?
-      return Puppet_X::Elastic::plugin_name arg
-    end
+    ret = args.select do |arg|
+      arg.is_a? String and not arg.empty?
+    end.first
 
-    raise Puppet::Error,
-      'could not determine plugin name'
+    if ret
+      Puppet_X::Elastic::plugin_name ret
+    else
+      raise Puppet::Error,
+        'could not determine plugin name'
+    end
   end
 end

--- a/lib/puppet/parser/functions/es_plugin_name.rb
+++ b/lib/puppet/parser/functions/es_plugin_name.rb
@@ -24,7 +24,11 @@ module Puppet::Parser::Functions
 
     args.each do |arg|
       next unless arg.is_a? String
+      next if arg.empty?
       return Puppet_X::Elastic::plugin_name arg
     end
+
+    raise Puppet::Error,
+      'could not determine plugin name'
   end
 end

--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
 
 require 'uri'
+require 'puppet_x/elastic/plugin_name'
 
 Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
   desc "A provider for the resource type `elasticsearch_plugin`,
@@ -53,9 +54,17 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
 
   def pluginfile
     if @resource[:plugin_path]
-      File.join(@resource[:plugin_dir], @resource[:plugin_path], '.name')
+      File.join(
+        @resource[:plugin_dir],
+        @resource[:plugin_path],
+        '.name'
+      )
     else
-      File.join(@resource[:plugin_dir], plugin_name(@resource[:name]), '.name')
+      File.join(
+        @resource[:plugin_dir],
+        Puppet_X::Elastic::plugin_name(@resource[:name]),
+        '.name'
+      )
     end
   end
 
@@ -72,24 +81,38 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
 
   def install1x
     if !@resource[:url].nil?
-      commands = [ plugin_name(@resource[:name]), '--url', @resource[:url] ]
+      [
+        Puppet_X::Elastic::plugin_name(@resource[:name]),
+        '--url',
+        @resource[:url]
+      ]
     elsif !@resource[:source].nil?
-      commands = [ plugin_name(@resource[:name]), '--url', "file://#{@resource[:source]}" ]
+      [
+        Puppet_X::Elastic::plugin_name(@resource[:name]),
+        '--url',
+        "file://#{@resource[:source]}"
+      ]
     else
-      commands = [ @resource[:name] ]
+      [
+        @resource[:name]
+      ]
     end
-    commands
   end
 
   def install2x
     if !@resource[:url].nil?
-      commands = [ @resource[:url] ]
+      [
+        @resource[:url]
+      ]
     elsif !@resource[:source].nil?
-      commands = [ "file://#{@resource[:source]}" ]
+      [
+        "file://#{@resource[:source]}"
+      ]
     else
-      commands = [ @resource[:name] ]
+      [
+        @resource[:name]
+      ]
     end
-    commands
   end
 
   def proxy_args url
@@ -178,17 +201,6 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
     return @es_version if is2x? && version.nil?
     return version.scan(/\d+\.\d+\.\d+(?:\-\S+)?/).first unless version.nil?
     return false
-  end
-
-  def plugin_name(plugin_name)
-    vendor, plugin, _version = plugin_name.split('/')
-
-    if plugin.nil?
-      # Not delineated by slashes; single plugin name
-      vendor
-    else
-      plugin.gsub(/(elasticsearch-|es-)/, '')
-    end
   end
 
 end

--- a/lib/puppet/provider/elasticsearch_plugin/plugin.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/plugin.rb
@@ -174,19 +174,21 @@ Puppet::Type.type(:elasticsearch_plugin).provide(:plugin) do
 
 
   def plugin_version(plugin_name)
-    vendor, plugin, version = plugin_name.split('/')
+    _vendor, _plugin, version = plugin_name.split('/')
     return @es_version if is2x? && version.nil?
     return version.scan(/\d+\.\d+\.\d+(?:\-\S+)?/).first unless version.nil?
     return false
   end
 
   def plugin_name(plugin_name)
-    vendor, plugin, version = plugin_name.split('/')
+    vendor, plugin, _version = plugin_name.split('/')
 
-    endname = vendor if plugin.nil? # If its a single name plugin like the ES 2.x official plugins
-    endname = plugin.gsub(/(elasticsearch-|es-)/, '') unless plugin.nil?
-
-    endname
+    if plugin.nil?
+      # Not delineated by slashes; single plugin name
+      vendor
+    else
+      plugin.gsub(/(elasticsearch-|es-)/, '')
+    end
   end
 
 end

--- a/lib/puppet_x/elastic/plugin_name.rb
+++ b/lib/puppet_x/elastic/plugin_name.rb
@@ -1,0 +1,16 @@
+module Puppet_X
+  module Elastic
+    # Attempt to guess at the plugin's final directory name
+    def self.plugin_name(original_string)
+      vendor, plugin, _version = original_string.split('/')
+
+      if plugin.nil?
+        # Not delineated by slashes; single plugin name in the style of
+        # commercial plugins post-2.x
+        vendor
+      else # strip off potential es prefixes and return the plugin name
+        plugin.gsub(/(elasticsearch-|es-)/, '')
+      end
+    end
+  end # of Elastic
+end # of Puppet_X

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -100,8 +100,12 @@ define elasticsearch::plugin(
       if empty($instances) {
         fail('no $instances defined')
       }
+
+      $_file_ensure = 'directory'
     }
-    'absent': { }
+    'absent': {
+      $_file_ensure = $ensure
+    }
     default: {
       fail("'${ensure}' is not a valid ensure parameter value")
     }
@@ -150,6 +154,8 @@ define elasticsearch::plugin(
     validate_string($url)
   }
 
+  $_module_dir = es_plugin_name($module_dir, $name)
+
   elasticsearch_plugin { $name:
     ensure      => $ensure,
     source      => $file_source,
@@ -157,5 +163,10 @@ define elasticsearch::plugin(
     proxy       => $_proxy,
     plugin_dir  => $::elasticsearch::plugindir,
     plugin_path => $module_dir,
+  } ->
+  file { "${elasticsearch::plugindir}/${_module_dir}":
+    ensure  => $_file_ensure,
+    mode    => 'o+Xr',
+    recurse => true,
   }
 }

--- a/spec/defines/004_elasticsearch_plugin_spec.rb
+++ b/spec/defines/004_elasticsearch_plugin_spec.rb
@@ -32,8 +32,17 @@ describe 'elasticsearch::plugin', :type => 'define' do
         :instances  => 'es-01'
       } end
 
-      it { should contain_elasticsearch__plugin('mobz/elasticsearch-head/1.0.0') }
-      it { should contain_elasticsearch_plugin('mobz/elasticsearch-head/1.0.0') }
+      it { should contain_elasticsearch__plugin(
+        'mobz/elasticsearch-head/1.0.0'
+      ) }
+      it { should contain_elasticsearch_plugin(
+        'mobz/elasticsearch-head/1.0.0'
+      ) }
+      it { should contain_file(
+        '/usr/share/elasticsearch/plugins/head'
+      ).that_requires(
+        'Elasticsearch_plugin[mobz/elasticsearch-head/1.0.0]'
+      ) }
     end
 
     context "Remove a plugin" do
@@ -44,8 +53,19 @@ describe 'elasticsearch::plugin', :type => 'define' do
         :instances  => 'es-01'
       } end
 
-      it { should contain_elasticsearch__plugin('mobz/elasticsearch-head/1.0.0') }
-      it { should contain_elasticsearch_plugin('mobz/elasticsearch-head/1.0.0').with(:ensure => 'absent') }
+      it { should contain_elasticsearch__plugin(
+        'mobz/elasticsearch-head/1.0.0'
+      ) }
+      it { should contain_elasticsearch_plugin(
+        'mobz/elasticsearch-head/1.0.0'
+      ).with(
+        :ensure => 'absent'
+      ) }
+      it { should contain_file(
+        '/usr/share/elasticsearch/plugins/head'
+      ).that_requires(
+        'Elasticsearch_plugin[mobz/elasticsearch-head/1.0.0]'
+      ) }
     end
 
   end

--- a/spec/defines/007_elasticsearch_shield_user_spec.rb
+++ b/spec/defines/007_elasticsearch_shield_user_spec.rb
@@ -63,6 +63,9 @@ describe 'elasticsearch::shield::user' do
       it { should contain_elasticsearch_shield_role_mapping('test_role') }
       it { should contain_elasticsearch__plugin('shield') }
       it { should contain_elasticsearch_plugin('shield') }
+      it { should contain_file(
+        '/usr/share/elasticsearch/plugins/shield'
+      ) }
       it { should contain_elasticsearch__shield__user('elastic')
         .that_comes_before([
         'Elasticsearch::Template[foo]'
@@ -101,6 +104,9 @@ describe 'elasticsearch::shield::user' do
       it { should contain_elasticsearch_shield_role_mapping('test_role') }
       it { should contain_elasticsearch__plugin('shield') }
       it { should contain_elasticsearch_plugin('shield') }
+      it { should contain_file(
+        '/usr/share/elasticsearch/plugins/shield'
+      ) }
       it { should contain_elasticsearch__shield__user('elastic')
         .that_comes_before([
         'Elasticsearch::Template[foo]',

--- a/spec/functions/es_plugin_name_spec.rb
+++ b/spec/functions/es_plugin_name_spec.rb
@@ -44,6 +44,16 @@ describe 'es_plugin_name' do
       .and_return('foo') }
   end
 
+  describe 'undef parameters' do
+    it { is_expected.to run
+      .with_params('', 'foo')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params('')
+      .and_raise_error(Puppet::Error, /could not/) }
+  end
+
   it 'should not change the original values' do
     argument1 = 'foo'
     original1 = argument1.dup

--- a/spec/functions/es_plugin_name_spec.rb
+++ b/spec/functions/es_plugin_name_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'es_plugin_name' do
+
+  describe 'exception handling' do
+    it { is_expected.to run.with_params().and_raise_error(
+      Puppet::ParseError, /wrong number of arguments/i
+    ) }
+  end
+
+  describe 'single arguments' do
+    it { is_expected.to run
+      .with_params('foo')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params('vendor/foo')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params('vendor/foo/1.0.0')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params('vendor/es-foo/1.0.0')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params('vendor/elasticsearch-foo/1.0.0')
+      .and_return('foo') }
+  end
+
+  describe 'multiple arguments' do
+    it { is_expected.to run
+      .with_params('foo', nil)
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params(nil, 'foo')
+      .and_return('foo') }
+
+    it { is_expected.to run
+      .with_params(nil, 0, 'foo', 'bar')
+      .and_return('foo') }
+  end
+
+  it 'should not change the original values' do
+    argument1 = 'foo'
+    original1 = argument1.dup
+
+    subject.call([argument1])
+    expect(argument1).to eq(original1)
+  end
+
+end

--- a/spec/unit/provider/elasticsearch_plugin/plugin_spec.rb
+++ b/spec/unit/provider/elasticsearch_plugin/plugin_spec.rb
@@ -27,7 +27,7 @@ shared_examples 'plugin provider' do |version, build|
           'install',
           ['http://url/to/my/plugin.zip'].tap do |args|
             if version.start_with? '1'
-              args.unshift(shortname, '--url')
+              args.unshift('kopf', '--url')
             else
               args
             end
@@ -43,7 +43,7 @@ shared_examples 'plugin provider' do |version, build|
           'install',
           ['file:///tmp/plugin.zip'].tap do |args|
             if version.start_with? '1'
-              args.unshift(shortname, '--url')
+              args.unshift('kopf', '--url')
             else
               args
             end
@@ -119,7 +119,6 @@ describe provider_class do
     provider.resource = resource
     provider
   end
-  let(:shortname) { provider.plugin_name(resource_name) }
 
   include_examples 'plugin provider',
     '1.x',


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

This resolves #565. Although most cases of restrictive umask settings are user-controlled, the plugin resources this module controls have finer-grained access to the necessary directories that need to be controlled, so a recursive `file` resource is a pretty straightforward way to ensure necessary plugin files are readable.