### PR TITLE
Fix elasticsearch::template HTTPS usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Bugfixes
 * Recursively enforce correct plugin directory mode to avoid Elasticsearch startup permissions errors.
 * Fixed an edge case where dependency cycles could arise when managing absent resources.
+* Elasticsearch templates now properly use HTTPS when instructed to do so.
 
 #### Changes
 * Updated the elasticsearch_template type to return more helpful error output.

--- a/lib/puppet/provider/elasticsearch_template/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_template/ruby.rb
@@ -47,6 +47,8 @@ Puppet::Type.type(:elasticsearch_template).provide(:ruby) do
     http = Net::HTTP.new uri.host, uri.port
     req = Net::HTTP::Get.new uri.request_uri
 
+    http.use_ssl = uri.scheme == 'https'
+
     response = rest http, req, validate_tls, timeout, username, password
 
     if response.code.to_i == 200
@@ -110,6 +112,7 @@ Puppet::Type.type(:elasticsearch_template).provide(:ruby) do
       resource[:name]
     ])
     http = Net::HTTP.new uri.host, uri.port
+    http.use_ssl = uri.scheme == 'https'
 
     case @property_flush[:ensure]
     when :absent

--- a/spec/unit/provider/elasticsearch_template/ruby.rb
+++ b/spec/unit/provider/elasticsearch_template/ruby.rb
@@ -116,4 +116,45 @@ describe Puppet::Type.type(:elasticsearch_template).provider(:ruby) do
     end
   end
 
+  describe 'https' do
+    before :all do
+      stub_request(:get, 'https://localhost:9200/_template').
+        to_return(
+          :status => 200,
+          :body => <<-EOS
+            {
+              "foobar-ssl": {
+                "aliases": {},
+                "mappings": {},
+                "order": 10,
+                "settings": {},
+                "template": "foobar-ssl-*"
+              }
+            }
+          EOS
+      )
+    end
+
+    it 'uses ssl' do
+      expect(described_class.templates(
+        'https', true, 'localhost', '9200', 10
+      ).map { |provider|
+        described_class.new(
+          provider
+        ).instance_variable_get(:@property_hash)
+      }).to contain_exactly({
+        :name => 'foobar-ssl',
+        :ensure => :present,
+        :provider => :ruby,
+        :content => {
+          'aliases' => {},
+          'mappings' => {},
+          'settings' => {},
+          'template' => 'foobar-ssl-*',
+          'order' => 10,
+        }
+      })
+    end
+  end
+
 end # of describe puppet type


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Per #688, the ruby provider actually never sets the SSL flag for the Net::HTTP object it uses (whoops!) This change sets the flag appropriately and also adds an explicit test to ensure we're validating it does so.