### PR TITLE
Fix plugindir mode to enforce o+Xr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 #### Bugfixes
+* Permissions on the Elasticsearch plugin directory have been fixed to permit world read rights.
 
 #### Changes
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -137,6 +137,7 @@ class elasticsearch::config {
       ensure => 'absent',
       force  => true,
       backup => false,
+      mode   => 'o+Xr',
     }
 
   }

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -276,7 +276,13 @@ describe 'elasticsearch', :type => 'class' do
         else
           it { should contain_package('elasticsearch').with(:ensure => 'purged') }
         end
-        it { should contain_file('/usr/share/elasticsearch/plugins').with(:ensure => 'absent') }
+        it {
+          should contain_file('/usr/share/elasticsearch/plugins')
+            .with(
+              :ensure => 'absent',
+              :mode => 'o+Xr'
+          )
+        }
 
       end
 


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
