### PR TITLE
Implement ca_file and ca_path passing to REST providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Permissions on the Elasticsearch plugin directory have been fixed to permit world read rights.
 
 #### Changes
+* The `api_ca_file` and `api_ca_path` parameters have been added to support custom CA bundles for API access.
 
 #### Testing changes
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ class { 'elasticsearch':
   api_timeout             => 10,
   api_basic_auth_username => undef,
   api_basic_auth_password => undef,
+  api_ca_file             => undef,
+  api_ca_path             => undef,
   validate_tls            => true,
 }
 ```
@@ -252,6 +254,8 @@ elasticsearch::template { 'templatename':
   api_timeout             => 60,
   api_basic_auth_username => 'admin',
   api_basic_auth_password => 'adminpassword',
+  api_ca_file             => '/etc/ssl/certs',
+  api_ca_path             => '/etc/pki/certs',
   validate_tls            => false,
   source                  => 'puppet:///path/to/template.json',
 }

--- a/lib/puppet/type/elasticsearch_template.rb
+++ b/lib/puppet/type/elasticsearch_template.rb
@@ -150,6 +150,14 @@ Puppet::Type.newtype(:elasticsearch_template) do
     desc 'Optional HTTP basic authentication plaintext password for Elasticsearch.'
   end
 
+  newparam(:ca_file) do
+    desc 'Absolute path to a CA file to authenticate server certificates against.'
+  end
+
+  newparam(:ca_path) do
+    desc 'Absolute path to a directory containing CA files to authenticate server certificates against.'
+  end
+
   validate do
 
     # Ensure that at least one source of template content has been provided

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,6 +282,16 @@
 #   Defines the default REST basic auth password for API authentication.
 #   Defaults to: undef
 #
+# [*api_ca_file*]
+#   Path to a CA file which will be used to validate server certs when
+#   communicating with the Elasticsearch API over HTTPS.
+#   Defaults to: undef
+#
+# [*api_ca_path*]
+#   Path to a directory with CA files which will be used to validate server
+#   certs when communicating with the Elasticsearch API over HTTPS.
+#   Defaults to: undef
+#
 # [*system_key*]
 #   Source for the Shield system key. Valid values are any that are
 #   supported for the file resource `source` parameter.
@@ -369,6 +379,8 @@ class elasticsearch(
   $api_timeout             = 10,
   $api_basic_auth_username = undef,
   $api_basic_auth_password = undef,
+  $api_ca_file             = undef,
+  $api_ca_path             = undef,
   $validate_tls            = true,
   $system_key              = undef,
 ) inherits elasticsearch::params {

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -60,13 +60,6 @@
 #   Default value inherited from elasticsearch::api_timeout: 10
 #   This variable is optional
 #
-# [*validate_tls*]
-#   Determines whether the validity of SSL/TLS certificates received from the
-#   Elasticsearch API should be verified or ignored.
-#   Value type is boolean
-#   Default value inherited from elasticsearch::validate_tls: true
-#   This variable is optional
-#
 # [*api_basic_auth_username*]
 #   HTTP basic auth username to use when communicating over the Elasticsearch
 #   API.
@@ -79,6 +72,27 @@
 #   API.
 #   Value type is String
 #   Default value inherited from elasticsearch::api_basic_auth_password: undef
+#   This variable is optional
+#
+# [*api_ca_file*]
+#   Path to a CA file which will be used to validate server certs when
+#   communicating with the Elasticsearch API over HTTPS.
+#   Value type is String
+#   Default value inherited from elasticsearch::api_ca_file: undef
+#   This variable is optional
+#
+# [*api_ca_path*]
+#   Path to a directory with CA files which will be used to validate server
+#   certs when communicating with the Elasticsearch API over HTTPS.
+#   Value type is String
+#   Default value inherited from elasticsearch::api_ca_path: undef
+#   This variable is optional
+#
+# [*validate_tls*]
+#   Determines whether the validity of SSL/TLS certificates received from the
+#   Elasticsearch API should be verified or ignored.
+#   Value type is boolean
+#   Default value inherited from elasticsearch::validate_tls: true
 #   This variable is optional
 #
 # === Authors
@@ -97,6 +111,8 @@ define elasticsearch::template (
   $api_timeout             = $elasticsearch::api_timeout,
   $api_basic_auth_username = $elasticsearch::_api_basic_auth_username,
   $api_basic_auth_password = $elasticsearch::_api_basic_auth_password,
+  $api_ca_file             = $elasticsearch::api_ca_file,
+  $api_ca_path             = $elasticsearch::api_ca_path,
   $validate_tls            = $elasticsearch::_validate_tls,
 ) {
   validate_string(
@@ -112,6 +128,8 @@ define elasticsearch::template (
   }
   if ! is_integer($api_port)    { fail('"api_port" is not an integer') }
   if ! is_integer($api_timeout) { fail('"api_timeout" is not an integer') }
+  if ($api_ca_file != undef) { validate_absolute_path($api_ca_file) }
+  if ($api_ca_path != undef) { validate_absolute_path($api_ca_path) }
 
   if ($file != undef) {
     warning('"file" parameter is deprecated; use $source instead')
@@ -150,6 +168,8 @@ define elasticsearch::template (
     timeout      => $api_timeout,
     username     => $api_basic_auth_username,
     password     => $api_basic_auth_password,
+    ca_file      => $api_ca_file,
+    ca_path      => $api_ca_path,
     validate_tls => $validate_tls,
   }
 }

--- a/spec/defines/003_elasticsearch_template_spec.rb
+++ b/spec/defines/003_elasticsearch_template_spec.rb
@@ -17,6 +17,20 @@ describe 'elasticsearch::template', :type => 'define' do
   EOS
   }
 
+  describe 'parameter validation' do
+    [:api_ca_file, :api_ca_path].each do |param|
+      let :params do {
+        :ensure => 'present',
+        :content => '{}',
+        param => 'foo/cert'
+      } end
+
+      it { is_expected.to compile
+        .and_raise_error(/absolute path/) }
+    end
+  end
+
+
   describe 'template from source' do
 
     let :params do {
@@ -61,6 +75,8 @@ describe 'elasticsearch::template', :type => 'define' do
         api_timeout => 11,
         api_basic_auth_username => 'elastic',
         api_basic_auth_password => 'password',
+        api_ca_file => '/foo/bar.pem',
+        api_ca_path => '/foo/',
         validate_tls => false,
       }
     EOS
@@ -75,6 +91,8 @@ describe 'elasticsearch::template', :type => 'define' do
       :timeout => 11,
       :username => 'elastic',
       :password => 'password',
+      :ca_file => '/foo/bar.pem',
+      :ca_path => '/foo/',
       :validate_tls => false
     ) }
   end

--- a/spec/unit/type/elasticsearch_template_spec.rb
+++ b/spec/unit/type/elasticsearch_template_spec.rb
@@ -12,6 +12,8 @@ describe Puppet::Type.type(:elasticsearch_template) do
       :port,
       :protocol,
       :validate_tls,
+      :ca_file,
+      :ca_path,
       :timeout,
       :username,
       :password


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Related to #690; some users may need to specify a specific CA bundle or path to CAs to validate against when performing API access operations. This solves both.

Note that, at least in Ruby ~1.8, these settings aren't well supported (if at all?), hence the `respond_to?` check. However, this fix solves peoples' problems, and we can revisit as necessary if problems arise with differing combinations of puppet/ruby.