### PR TITLE
Add ordering directives to SystemD unit file

### DIFF
--- a/templates/etc/init.d/elasticsearch.systemd.erb
+++ b/templates/etc/init.d/elasticsearch.systemd.erb
@@ -1,6 +1,8 @@
 [Unit]
 Description=Starts and stops a single elasticsearch instance on this system
 Documentation=http://www.elasticsearch.org
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)

Without any ordering directives instances start too early
during the boot process. This causes problems in cases
with data directory on the iSCSI device for example.

These directives (also present in the original SystemD service
file distributed in Elasticsearch RPM) fix the ordering problem.