### PR TITLE
Change mkdir in elasticsearch.Debian init script to take in account when DATA_DIR, LOG_DIR and/or WORK_DIR is an empty variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The service systemd unit now `Wants=` a network target to fix bootup parallelization problems.
 * Recursively create the logdir for elasticsearch when creating multiple instances
 * Files and directories with root ownership now specify UID/GID 0 instead to improve compatability with *BSDs.
+* Elasticsearch Debian init file changed to avoid throwing errors when DATA_DIR, WORK_DIR and/or LOG_DIR were an empty variable.
 
 #### Changes
 * The `api_ca_file` and `api_ca_path` parameters have been added to support custom CA bundles for API access.

--- a/templates/etc/init.d/elasticsearch.Debian.erb
+++ b/templates/etc/init.d/elasticsearch.Debian.erb
@@ -149,7 +149,9 @@ case "$1" in
 	fi
 
 	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
+	for DIR in "$DATA_DIR" "$LOG_DIR" "$WORK_DIR"; do
+		[ ! -z "$DIR" ] && mkdir -p "$DIR" && chown "$ES_USER":"$ES_GROUP" "$DIR"
+	done
 	touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
 
 	if [ -n "$MAX_OPEN_FILES" ]; then


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
