### PR TITLE
Enforce proper numeric datatypes in config hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 #### Changes
 * The `api_ca_file` and `api_ca_path` parameters have been added to support custom CA bundles for API access.
+* Numerics in elasticsearch.yml will always be properly unquoted.
 
 #### Testing changes
 

--- a/spec/templates/001_elasticsearch.yml.erb_spec.rb
+++ b/spec/templates/001_elasticsearch.yml.erb_spec.rb
@@ -74,4 +74,16 @@ describe 'elasticsearch.yml.erb' do
       }.config))
   end
 
+  it 'should not quote numeric values' do
+    harness.set(
+      '@data', {
+        'some.setting' => '10'
+      }
+    )
+
+    expect( YAML.load(harness.run) ).to eq( YAML.load(%q{
+      some.setting: 10
+    }.config))
+  end
+
 end

--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -1,6 +1,7 @@
 ### MANAGED BY PUPPET ###
 <%-
   $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..","..","lib"))
+  require 'puppet_x/elastic/deep_to_i'
   require 'puppet_x/elastic/hash'
 
   @yml_string = ''
@@ -8,7 +9,11 @@
   if !@data.empty?
 
     # Sort Hash and transform it into yaml
-    @yml_string += @data.extend(Puppet_X::Elastic::SortedHash).to_yaml
+    @yml_string += Puppet_X::Elastic::deep_to_i(
+      @data
+    ).extend(
+      Puppet_X::Elastic::SortedHash
+    ).to_yaml
 
     # Puppet < 4 uses ZAML, which has some deviations from Puppet 4 YAML
     # implementation


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

In some cases numerics passed in from Puppet can end up as strings, which gets relayed into the config yaml as quoted numbers. This change enforces all numerics to be represented as numbers in the elasticsearch.yml config file.