### PR TITLE
Update the apt::source call to not cause deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## x.x.x (Month Day, Year)
+
+### Summary
+
+#### Features
+
+#### Bugfixes
+
+#### Changes
+
+#### Testing changes
+
 ## 0.14.0 (October 12, 2016)
 
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 #### Bugfixes
+* Update the apt::source call to not cause deprecation warnings
 
 #### Changes
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,14 +36,19 @@ class elasticsearch::repo {
       Class['apt::update'] -> Package[$elasticsearch::package_name]
 
       apt::source { 'elasticsearch':
-        ensure      => $elasticsearch::ensure,
-        location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
-        release     => 'stable',
-        repos       => 'main',
-        key         => $::elasticsearch::repo_key_id,
-        key_source  => $::elasticsearch::repo_key_source,
-        include_src => false,
-        pin         => $elasticsearch::repo_priority,
+        ensure   => $elasticsearch::ensure,
+        location => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
+        release  => 'stable',
+        repos    => 'main',
+        key      => {
+          'id'     => $::elasticsearch::repo_key_id,
+          'source' => $::elasticsearch::repo_key_source,
+        },
+        include  => {
+          'src' => false,
+          'deb' => true,
+        },
+        pin      => $elasticsearch::repo_priority,
       }
     }
     'RedHat', 'Linux': {

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.4.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "richardc/datacat",


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:
- [v] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [v] Rebased/up-to-date with base branch
- [ ] Tests pass
- [v] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)

Update the apt::source call to not cause deprecation warnings
[puppetserver] Scope(Apt::Source[elasticsearch]) $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
[puppetserver] Scope(Apt::Source[elasticsearch]) $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => http://packages.elastic.co/GPG-KEY-elasticsearch } instead.

Gave up trying to test with provided tooling since they don't work and trying to get them to work kills the benefits of a 2-minute fix to an apt::source call. Code is being used in production, and works as intended, you'll have to take my word for it.
