### PR TITLE
Elasticsearch 5.x initial support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,8 @@
 fixtures:
   forge_modules:
+    archive:
+      repo: puppet/archive
+      ref: 0.5.1
     stdlib:
       repo: puppetlabs/stdlib
       ref: 4.11.0

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -22,5 +22,8 @@ fixtures:
       repo: darin/zypprepo
       ref: 1.0.2
     java_ks: puppetlabs/java_ks
+    sysctl:
+      repo: thias/sysctl
+      ref: 1.0.6
   symlinks:
     elasticsearch: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ matrix:
   - env: DISTRO=sles-12-x64
   - env: DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=2016.1.2
   fast_finish: true
-before_script:
-# Required for 5.x to startup.
-- sysctl -w vm.max_map_count=262144
 script:
 - make test-$TEST_SUITE
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ matrix:
   - env: DISTRO=sles-12-x64
   - env: DISTRO=ubuntu-server-1204-x64 PE=true PE_VER=2016.1.2
   fast_finish: true
+before_script:
+# Required for 5.x to startup.
+- sysctl -w vm.max_map_count=262144
 script:
 - make test-$TEST_SUITE
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Summary
 * Support for Ubuntu Xenial (16.04) formally declared.
+* Initial support for running Elasticsearch 5.x series.
 
 #### Features
 * Support management of 5.x-style Elastic yum/apt package repositories.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This module has been tested against all versions of ES 1.x, 2.x, and 5.x.
 * [Augeas](http://augeas.net/)
 * [puppetlabs-java](https://forge.puppetlabs.com/puppetlabs/java) for Java installation (optional).
 * [puppetlabs-java_ks](https://forge.puppetlabs.com/puppetlabs/java_ks) for Shield certificate management (optional).
+* [thias-sysctl](https://forge.puppet.com/thias/sysctl) for managing sysctl properties.
 
 #### Repository management
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 This module sets up [Elasticsearch](https://www.elastic.co/overview/elasticsearch/) instances with additional resource for plugins, templates, and more.
 
-This module has been tested against all versions of ES 1.x and 2.x.
+This module has been tested against all versions of ES 1.x, 2.x, and 5.x.
 
 ## Setup
 
@@ -60,11 +60,15 @@ Declare the top-level `elasticsearch` class (managing repositories) and set up a
 class { 'elasticsearch':
   java_install => true,
   manage_repo  => true,
-  repo_version => '2.x',
+  repo_version => '5.x',
 }
 
 elasticsearch::instance { 'es-01': }
 ```
+
+**Note**: Elasticsearch 5.x requires a recent version of the JVM.
+If you are on a recent version of your distribution of choice (such as Ubuntu 16.04 or CentOS 7), setting `java_install => true` will work out-of-the-box.
+If you are on an earlier distribution, you may need to take additional measures to install Java 1.8.
 
 ## Usage
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,11 +26,6 @@ class elasticsearch::config {
 
   #### Configuration
 
-  File {
-    owner => $elasticsearch::elasticsearch_user,
-    group => $elasticsearch::elasticsearch_group,
-  }
-
   Exec {
     path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     cwd  => '/',
@@ -41,33 +36,48 @@ class elasticsearch::config {
     file {
       $elasticsearch::configdir:
         ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
         mode   => '0644';
       $elasticsearch::datadir:
-        ensure => 'directory';
+        ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user;
       $elasticsearch::logdir:
         ensure  => 'directory',
         group   => undef,
+        owner   => $elasticsearch::elasticsearch_user,
         mode    => '0644',
         recurse => true;
       $elasticsearch::plugindir:
         ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
         mode   => 'o+Xr';
       "${elasticsearch::homedir}/lib":
         ensure  => 'directory',
+        group   => $elasticsearch::elasticsearch_group,
+        owner   => $elasticsearch::elasticsearch_user,
         recurse => true;
       $elasticsearch::params::homedir:
-        ensure => 'directory';
+        ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user;
       "${elasticsearch::params::homedir}/templates_import":
         ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
         mode   => '0644';
       "${elasticsearch::params::homedir}/scripts":
         ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
         mode   => '0644';
       "${elasticsearch::params::homedir}/shield":
         ensure => 'directory',
         mode   => '0644',
-        owner  => 'root',
-        group  => '0';
+        group  => '0',
+        owner  => 'root';
       '/etc/elasticsearch/elasticsearch.yml':
         ensure => 'absent';
       '/etc/elasticsearch/logging.yml':
@@ -82,19 +92,20 @@ class elasticsearch::config {
       file { $elasticsearch::params::pid_dir:
         ensure  => 'directory',
         group   => undef,
+        owner   => $elasticsearch::elasticsearch_user,
         recurse => true,
       }
 
       if ($elasticsearch::service_providers == 'systemd') {
-        $user = $elasticsearch::elasticsearch_user
         $group = $elasticsearch::elasticsearch_group
+        $user = $elasticsearch::elasticsearch_user
         $pid_dir = $elasticsearch::params::pid_dir
 
         file { '/usr/lib/tmpfiles.d/elasticsearch.conf':
           ensure  => 'file',
           content => template("${module_name}/usr/lib/tmpfiles.d/elasticsearch.conf.erb"),
-          owner   => 'root',
           group   => '0',
+          owner   => 'root',
         }
       }
     }
@@ -113,6 +124,10 @@ class elasticsearch::config {
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
       }
+    }
+
+    sysctl { 'vm.max_map_count':
+      value => 262144,
     }
 
   } elsif ( $elasticsearch::ensure == 'absent' ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -72,6 +72,8 @@ class elasticsearch::config {
         ensure => 'absent';
       '/etc/elasticsearch/logging.yml':
         ensure => 'absent';
+      '/etc/elasticsearch/log4j2.properties':
+        ensure => 'absent';
       '/etc/init.d/elasticsearch':
         ensure => 'absent';
     }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -241,7 +241,11 @@ define elasticsearch::instance(
       } else {
         $instance_logging_config = { }
       }
-      $logging_hash = merge($elasticsearch::params::logging_defaults, $main_logging_config, $instance_logging_config)
+      $logging_hash = merge(
+        $elasticsearch::params::logging_defaults,
+        $main_logging_config,
+        $instance_logging_config
+      )
       if ($logging_template != undef ) {
         $logging_content = template($logging_template)
       } elsif ($elasticsearch::logging_template != undef) {

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -137,7 +137,11 @@ define elasticsearch::service::init(
         }
       }
 
-      $init_defaults_pre_hash = { 'ES_USER' => $elasticsearch::elasticsearch_user, 'ES_GROUP' => $elasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
+      $init_defaults_pre_hash = {
+        'ES_USER' => $elasticsearch::elasticsearch_user,
+        'ES_GROUP' => $elasticsearch::elasticsearch_group,
+        'MAX_OPEN_FILES' => '65536'
+      }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -140,7 +140,7 @@ define elasticsearch::service::init(
       $init_defaults_pre_hash = {
         'ES_USER' => $elasticsearch::elasticsearch_user,
         'ES_GROUP' => $elasticsearch::elasticsearch_group,
-        'MAX_OPEN_FILES' => '65536'
+        'MAX_OPEN_FILES' => '65536',
       }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 

--- a/manifests/service/openrc.pp
+++ b/manifests/service/openrc.pp
@@ -135,7 +135,11 @@ define elasticsearch::service::openrc(
         }
       }
 
-      $init_defaults_pre_hash = { 'ES_USER' => $elasticsearch::elasticsearch_user, 'ES_GROUP' => $elasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
+      $init_defaults_pre_hash = {
+        'ES_USER' => $elasticsearch::elasticsearch_user,
+        'ES_GROUP' => $elasticsearch::elasticsearch_group,
+        'MAX_OPEN_FILES' => '65536'
+      }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":

--- a/manifests/service/openrc.pp
+++ b/manifests/service/openrc.pp
@@ -138,7 +138,7 @@ define elasticsearch::service::openrc(
       $init_defaults_pre_hash = {
         'ES_USER' => $elasticsearch::elasticsearch_user,
         'ES_GROUP' => $elasticsearch::elasticsearch_group,
-        'MAX_OPEN_FILES' => '65536'
+        'MAX_OPEN_FILES' => '65536',
       }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -131,7 +131,11 @@ define elasticsearch::service::systemd(
           }
         }
       }
-      $init_defaults_pre_hash = { 'ES_USER' => $elasticsearch::elasticsearch_user, 'ES_GROUP' => $elasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
+      $init_defaults_pre_hash = {
+        'ES_USER' => $elasticsearch::elasticsearch_user,
+        'ES_GROUP' => $elasticsearch::elasticsearch_group,
+        'MAX_OPEN_FILES' => '65536'
+      }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":
@@ -149,7 +153,7 @@ define elasticsearch::service::systemd(
       if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_OPEN_FILES')) {
         $nofile = $new_init_defaults['MAX_OPEN_FILES']
       }else{
-        $nofile = '65535'
+        $nofile = '65536'
       }
 
       if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_LOCKED_MEMORY')) {

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -134,7 +134,7 @@ define elasticsearch::service::systemd(
       $init_defaults_pre_hash = {
         'ES_USER' => $elasticsearch::elasticsearch_user,
         'ES_GROUP' => $elasticsearch::elasticsearch_group,
-        'MAX_OPEN_FILES' => '65536'
+        'MAX_OPEN_FILES' => '65536',
       }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,10 @@
       "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
+      "name": "thias/sysctl",
+      "version_requirement": ">= 1.0.6 < 2.0.0"
+    },
+    {
       "name": "ceritsc/yum",
       "version_requirement": ">= 0.9.6 < 1.0.0"
     }

--- a/spec/acceptance/021_es2x_spec.rb
+++ b/spec/acceptance/021_es2x_spec.rb
@@ -27,8 +27,6 @@ describe 'elasticsearch 2x' do
 
           Elasticsearch::Plugin { instances => 'es-01' }
           elasticsearch::plugin { 'cloud-aws': }
-          elasticsearch::plugin { 'marvel-agent': }
-          elasticsearch::plugin { 'license': }
         EOS
 
         it 'applies cleanly' do
@@ -103,8 +101,6 @@ describe 'elasticsearch 2x' do
 
           Elasticsearch::Plugin { instances => 'es-01' }
           elasticsearch::plugin { 'cloud-aws': }
-          elasticsearch::plugin { 'marvel-agent': }
-          elasticsearch::plugin { 'license': }
         EOS
 
         it 'applies cleanly' do

--- a/spec/acceptance/021_es2x_spec.rb
+++ b/spec/acceptance/021_es2x_spec.rb
@@ -24,9 +24,6 @@ describe 'elasticsearch 2x' do
               'http.port' => '#{test_settings['port_a']}'
             }
           }
-
-          Elasticsearch::Plugin { instances => 'es-01' }
-          elasticsearch::plugin { 'cloud-aws': }
         EOS
 
         it 'applies cleanly' do
@@ -37,32 +34,8 @@ describe 'elasticsearch 2x' do
         end
       end
 
-      describe file('/usr/share/elasticsearch/plugins/cloud-aws') do
-        it { should be_directory }
-      end
-
       describe port(test_settings['port_a']) do
         it 'open', :with_retries do should be_listening end
-      end
-
-      describe server :container do
-        describe http(
-          "http://localhost:#{test_settings['port_a']}/_cluster/stats",
-        ) do
-          it 'returns cloud-aws with version 2.0.0', :with_retries do
-            json = JSON.parse(response.body)
-            plugins = json['nodes']['plugins'].map do |h|
-              {
-                name: h['name'],
-                version: h['version']
-              }
-            end
-            expect(plugins).to include({
-              name: 'cloud-aws',
-              version: '2.0.0'
-            })
-          end
-        end
       end
 
       describe server :container do
@@ -98,9 +71,6 @@ describe 'elasticsearch 2x' do
               'http.port' => '#{test_settings['port_a']}'
             }
           }
-
-          Elasticsearch::Plugin { instances => 'es-01' }
-          elasticsearch::plugin { 'cloud-aws': }
         EOS
 
         it 'applies cleanly' do
@@ -111,32 +81,8 @@ describe 'elasticsearch 2x' do
         end
       end
 
-      describe file('/usr/share/elasticsearch/plugins/cloud-aws') do
-        it { should be_directory }
-      end
-
       describe port(test_settings['port_a']) do
         it 'open', :with_retries do should be_listening end
-      end
-
-      describe server :container do
-        describe http(
-          "http://localhost:#{test_settings['port_a']}/_cluster/stats",
-        ) do
-          it 'reports cloud-aws as upgraded', :with_retries do
-            json = JSON.parse(response.body)
-            plugins = json['nodes']['plugins'].map do |h|
-              {
-                name: h['name'],
-                version: h['version']
-              }
-            end
-            expect(plugins).to include({
-              name: 'cloud-aws',
-              version: '2.0.1'
-            })
-          end
-        end
       end
 
       describe server :container do

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -31,8 +31,8 @@ describe 'elasticsearch 5.x' do
           manage_repo => true,
           repo_version => '#{test_settings['repo_version5x']}',
           java_install => #{java_install},
-          version => '5.0.0',
           restart_on_change => true,
+          version => '5.0.1',
         }
 
         elasticsearch::instance { 'es-01':
@@ -63,7 +63,7 @@ describe 'elasticsearch 5.x' do
         it 'runs version 5', :with_retries do
           expect(
             JSON.parse(response.body)['version']['number']
-          ).to eq('5.0.0')
+          ).to eq('5.0.1')
         end
       end
     end

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper_acceptance'
+
+describe 'elasticsearch 5.x' do
+  # Java 8 is only easy to manage on recent distros
+  if fact('osfamily') == 'RedHat' or fact('lsbdistcodename') == 'xenial'
+    # On CentOS/RedHat 7, we can just trust packages of java are recent
+    if fact('operatingsystemmajrelease') == '7'
+      java_install = true
+    else
+      # Otherwise, grab the Oracle JRE 8 package
+      java_install = false
+      java_snippet = <<-EOS
+        java::oracle { 'jre8':
+          java_se => 'jre',
+        }
+      EOS
+    end
+
+    describe 'manifest' do
+      pp = <<-EOS
+        class { 'elasticsearch':
+          config => {
+            'node.name' => 'elasticsearch001',
+            'cluster.name' => '#{test_settings['cluster_name']}',
+            'network.host' => '0.0.0.0',
+          },
+          manage_repo => true,
+          repo_version => '#{test_settings['repo_version5x']}',
+          java_install => #{java_install},
+          version => '5.0.0',
+          restart_on_change => true,
+        }
+
+        elasticsearch::instance { 'es-01':
+          config => {
+            'node.name' => 'elasticsearch001',
+            'http.port' => '#{test_settings['port_a']}'
+          }
+        }
+      EOS
+      if not java_install
+        pp = java_snippet + '->' + pp
+      end
+
+      it 'applies cleanly' do
+        apply_manifest pp, :catch_failures => true
+      end
+      it 'is idempotent' do
+        apply_manifest pp , :catch_changes  => true
+      end
+    end
+
+    describe port(test_settings['port_a']) do
+      it 'open', :with_retries do should be_listening end
+    end
+
+    describe server :container do
+      describe http "http://localhost:#{test_settings['port_a']}" do
+        it 'reports ES as upgraded', :with_retries do
+          expect(
+            JSON.parse(response.body)['version']['number']
+          ).to eq('5.0.0')
+        end
+      end
+    end
+  else
+    describe 'unsupported' do
+      pending 'testing on distribution'
+    end
+  end
+end

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper_acceptance'
 
 describe 'elasticsearch 5.x' do
   # Java 8 is only easy to manage on recent distros
-  if fact('osfamily') == 'RedHat' or fact('lsbdistcodename') == 'xenial'
+  if (fact('osfamily') == 'RedHat' and \
+      not (fact('operatingsystem') == 'OracleLinux' and \
+       fact('operatingsystemmajrelease') == '6')) or \
+      fact('lsbdistcodename') == 'xenial'
     # On earlier versions of CentOS/RedHat 7, manually get JRE 1.8
     if fact('operatingsystemmajrelease') == '6'
       # Otherwise, grab the Oracle JRE 8 package

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -3,17 +3,21 @@ require 'spec_helper_acceptance'
 describe 'elasticsearch 5.x' do
   # Java 8 is only easy to manage on recent distros
   if fact('osfamily') == 'RedHat' or fact('lsbdistcodename') == 'xenial'
-    # On CentOS/RedHat 7, we can just trust packages of java are recent
-    if fact('operatingsystemmajrelease') == '7'
-      java_install = true
-    else
+    # On earlier versions of CentOS/RedHat 7, manually get JRE 1.8
+    if fact('operatingsystemmajrelease') == '6'
       # Otherwise, grab the Oracle JRE 8 package
       java_install = false
       java_snippet = <<-EOS
+        package { 'java-openjdk' :
+          ensure => absent
+        } ->
         java::oracle { 'jre8':
           java_se => 'jre',
         }
       EOS
+    else
+      # Otherwise the distro should be recent enough to have JRE 1.8
+      java_install = true
     end
 
     describe 'manifest' do

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -60,7 +60,7 @@ describe 'elasticsearch 5.x' do
 
     describe server :container do
       describe http "http://localhost:#{test_settings['port_a']}" do
-        it 'reports ES as upgraded', :with_retries do
+        it 'runs version 5', :with_retries do
           expect(
             JSON.parse(response.body)['version']['number']
           ).to eq('5.0.0')

--- a/spec/acceptance/022_es5x_spec.rb
+++ b/spec/acceptance/022_es5x_spec.rb
@@ -8,7 +8,7 @@ describe 'elasticsearch 5.x' do
       # Otherwise, grab the Oracle JRE 8 package
       java_install = false
       java_snippet = <<-EOS
-        package { 'java-openjdk' :
+        package { 'java-1.7.0-openjdk' :
           ensure => absent
         } ->
         java::oracle { 'jre8':
@@ -43,7 +43,7 @@ describe 'elasticsearch 5.x' do
         }
       EOS
       if not java_install
-        pp = java_snippet + '->' + pp
+        pp = java_snippet + "->\n" + pp
       end
 
       it 'applies cleanly' do

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -12,5 +12,6 @@ HOSTS:
     docker_image_commands:
       - yum install -y wget tar which
       - rm /etc/init/tty.conf
+      - echo -e "elasticsearch hard nproc 2048\nelasticsearch soft nproc 2048" >> /etc/security/limits.conf
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/oracle-6-x64.yml
+++ b/spec/acceptance/nodesets/oracle-6-x64.yml
@@ -12,5 +12,6 @@ HOSTS:
     docker_image_commands:
       - yum install -y wget
       - rm /etc/init/tty.conf
+      - echo -e "elasticsearch hard nproc 2048\nelasticsearch soft nproc 2048" >> /etc/security/limits.conf
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1604-x64.yml
@@ -11,7 +11,7 @@ HOSTS:
     docker_preserve_image: true
     docker_image_commands:
       - apt-get update
-      - apt-get install -yq libssl-dev puppet
+      - apt-get install -yq libssl-dev puppet apt-transport-https
       - locale-gen en_US en_US.UTF-8
       - dpkg-reconfigure locales
 CONFIG:

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -96,6 +96,13 @@ describe 'elasticsearch', :type => 'class' do
           .with(:ensure => 'absent') }
         it { should contain_file('/etc/elasticsearch/log4j2.properties')
           .with(:ensure => 'absent') }
+
+        # System-level settings
+        it { should contain_sysctl(
+          'vm.max_map_count'
+        ).with(
+          :value => 262144
+        ) }
       end
 
       context 'package installation' do

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -86,9 +86,16 @@ describe 'elasticsearch', :type => 'class' do
         end
 
         # file removal from package
-        it { should contain_file('/etc/init.d/elasticsearch').with(:ensure => 'absent') }
-        it { should contain_file('/etc/elasticsearch/elasticsearch.yml').with(:ensure => 'absent') }
-        it { should contain_file('/etc/elasticsearch/logging.yml').with(:ensure => 'absent') }
+        it { should contain_file('/etc/init.d/elasticsearch')
+          .with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/elasticsearch.yml')
+          .with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/logging.yml')
+          .with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/log4j2.properties')
+          .with(:ensure => 'absent') }
+        it { should contain_file('/etc/elasticsearch/log4j2.properties')
+          .with(:ensure => 'absent') }
       end
 
       context 'package installation' do

--- a/spec/classes/001_hiera_spec.rb
+++ b/spec/classes/001_hiera_spec.rb
@@ -38,6 +38,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/etc/elasticsearch/es-01').with(:ensure => 'directory') }
         it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml') }
         it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
+        it { should contain_file('/etc/elasticsearch/es-01/log4j2.properties') }
         it { should contain_exec('mkdir_logdir_elasticsearch_es-01').with(:command => 'mkdir -p /var/log/elasticsearch/es-01') }
         it { should contain_exec('mkdir_datadir_elasticsearch_es-01').with(:command => 'mkdir -p /usr/share/elasticsearch/data/es-01') }
         it { should contain_file('/usr/share/elasticsearch/data/es-01') }
@@ -67,6 +68,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/etc/elasticsearch/es-01').with(:ensure => 'directory') }
         it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml') }
         it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
+        it { should contain_file('/etc/elasticsearch/es-01/log4j2.properties') }
         it { should contain_exec('mkdir_logdir_elasticsearch_es-01') }
         it { should contain_exec('mkdir_datadir_elasticsearch_es-01') }
         it { should contain_file('/usr/share/elasticsearch/data/es-01') }
@@ -87,6 +89,7 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_file('/etc/elasticsearch/es-02').with(:ensure => 'directory') }
         it { should contain_file('/etc/elasticsearch/es-02/elasticsearch.yml') }
         it { should contain_file('/etc/elasticsearch/es-02/logging.yml') }
+        it { should contain_file('/etc/elasticsearch/es-02/log4j2.properties') }
         it { should contain_exec('mkdir_logdir_elasticsearch_es-02') }
         it { should contain_exec('mkdir_datadir_elasticsearch_es-02') }
         it { should contain_file('/usr/share/elasticsearch/data/es-02') }
@@ -172,6 +175,7 @@ describe 'elasticsearch', :type => 'class' do
       it { should contain_file('/etc/elasticsearch/default').with(:ensure => 'directory') }
       it { should contain_file('/etc/elasticsearch/default/elasticsearch.yml') }
       it { should contain_file('/etc/elasticsearch/default/logging.yml') }
+      it { should contain_file('/etc/elasticsearch/default/log4j2.properties') }
       it { should contain_exec('mkdir_logdir_elasticsearch_default') }
       it { should contain_exec('mkdir_datadir_elasticsearch_default') }
       it { should contain_file('/usr/share/elasticsearch/data/default') }
@@ -193,6 +197,7 @@ describe 'elasticsearch', :type => 'class' do
       it { should contain_file('/etc/elasticsearch/es-01').with(:ensure => 'directory') }
       it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml') }
       it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
+      it { should contain_file('/etc/elasticsearch/es-01/log4j2.properties') }
       it { should contain_exec('mkdir_logdir_elasticsearch_es-01').with(:command => 'mkdir -p /var/log/elasticsearch/es-01') }
       it { should contain_exec('mkdir_datadir_elasticsearch_es-01').with(:command => 'mkdir -p /usr/share/elasticsearch/data/es-01') }
       it { should contain_file('/usr/share/elasticsearch/data/es-01') }

--- a/spec/defines/005_elasticsearch_instance_spec.rb
+++ b/spec/defines/005_elasticsearch_instance_spec.rb
@@ -148,6 +148,7 @@ describe 'elasticsearch::instance', :type => 'define' do
       it { should contain_datacat('/etc/elasticsearch/es-01/elasticsearch.yml') }
 
       it { should contain_file('/etc/elasticsearch/es-01/logging.yml') }
+      it { should contain_file('/etc/elasticsearch/es-01/log4j2.properties') }
       it { should contain_file('/usr/share/elasticsearch/scripts') }
       it { should contain_file('/usr/share/elasticsearch/shield') }
       it { should contain_file('/etc/elasticsearch/es-01/scripts').with(:target => '/usr/share/elasticsearch/scripts') }
@@ -170,6 +171,7 @@ describe 'elasticsearch::instance', :type => 'define' do
       it { should contain_datacat('/etc/elasticsearch-config/es-01/elasticsearch.yml') }
 
       it { should contain_file('/etc/elasticsearch-config/es-01/logging.yml') }
+      it { should contain_file('/etc/elasticsearch-config/es-01/log4j2.properties') }
       it { should contain_file('/usr/share/elasticsearch/scripts') }
       it { should contain_file('/usr/share/elasticsearch/shield') }
       it { should contain_file('/etc/elasticsearch-config/es-01/scripts').with(:target => '/usr/share/elasticsearch/scripts') }
@@ -188,6 +190,7 @@ describe 'elasticsearch::instance', :type => 'define' do
       it { should contain_datacat('/etc/elasticsearch-config/es-01/elasticsearch.yml') }
 
       it { should contain_file('/etc/elasticsearch-config/es-01/logging.yml') }
+      it { should contain_file('/etc/elasticsearch-config/es-01/log4j2.properties') }
       it { should contain_file('/usr/share/elasticsearch/scripts') }
       it { should contain_file('/usr/share/elasticsearch/shield') }
       it { should contain_file('/etc/elasticsearch-config/es-01/scripts').with(:target => '/usr/share/elasticsearch/scripts') }
@@ -457,6 +460,7 @@ describe 'elasticsearch::instance', :type => 'define' do
     it { should contain_datacat('/etc/elasticsearch/es-01/elasticsearch.yml').with(:owner => 'myesuser', :group => 'myesgroup') }
     it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml').with(:owner => 'myesuser', :group => 'myesgroup') }
     it { should contain_file('/etc/elasticsearch/es-01/logging.yml').with(:owner => 'myesuser', :group => 'myesgroup') }
+    it { should contain_file('/etc/elasticsearch/es-01/log4j2.properties').with(:owner => 'myesuser', :group => 'myesgroup') }
   end
 
   context 'setting different service status then main class' do

--- a/spec/defines/010_elasticsearch_service_init_spec.rb
+++ b/spec/defines/010_elasticsearch_service_init_spec.rb
@@ -89,7 +89,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
             "set ES_GROUP 'elasticsearch'",
             "set ES_HOME '/usr/share/elasticsearch'",
             "set ES_USER 'elasticsearch'",
-            "set MAX_OPEN_FILES '65535'",
+            "set MAX_OPEN_FILES '65536'",
           ].join("\n") << "\n",
           :before => 'Service[elasticsearch-instance-es-01]'
         )
@@ -141,7 +141,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
           'defaults_es-01'
         ).with(
           :incl => '/etc/sysconfig/elasticsearch-es-01',
-          :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65535'\n"
+          :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\nset MAX_OPEN_FILES '65536'\n"
         ) }
         it { should contain_augeas(
           'defaults_es-01'

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -107,7 +107,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_GROUP 'elasticsearch'",
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
-                "set MAX_OPEN_FILES '65535'"
+                "set MAX_OPEN_FILES '65536'"
               ].join("\n") << "\n",
               :before => 'Service[elasticsearch-instance-es-01]'
           ) }
@@ -156,7 +156,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_GROUP 'elasticsearch'",
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
-                "set MAX_OPEN_FILES '65535'"
+                "set MAX_OPEN_FILES '65536'"
               ].join("\n") << "\n"
             )}
             it { should contain_augeas(

--- a/spec/functions/concat_merge_spec.rb
+++ b/spec/functions/concat_merge_spec.rb
@@ -160,7 +160,7 @@ describe 'concat_merge' do
     argument2 = { 'key2' => 'value2' }
     original2 = argument2.dup
 
-    subject.call([argument1, argument2])
+    subject.execute(argument1, argument2)
     expect(argument1).to eq(original1)
     expect(argument2).to eq(original2)
   end

--- a/spec/functions/deep_implode_spec.rb
+++ b/spec/functions/deep_implode_spec.rb
@@ -104,7 +104,7 @@ describe 'deep_implode' do
     argument1 = { 'key1' => 'value1' }
     original1 = argument1.dup
 
-    subject.call([argument1])
+    subject.execute(argument1)
     expect(argument1).to eq(original1)
   end
 

--- a/spec/functions/es_plugin_name_spec.rb
+++ b/spec/functions/es_plugin_name_spec.rb
@@ -58,7 +58,7 @@ describe 'es_plugin_name' do
     argument1 = 'foo'
     original1 = argument1.dup
 
-    subject.call([argument1])
+    subject.execute(argument1)
     expect(argument1).to eq(original1)
   end
 

--- a/spec/spec_acceptance_common.rb
+++ b/spec/spec_acceptance_common.rb
@@ -1,6 +1,7 @@
   test_settings['cluster_name'] = SecureRandom.hex(10)
 
   test_settings['repo_version2x']          = '2.x'
+  test_settings['repo_version5x']          = '5.x'
   test_settings['repo_version']            = '1.7'
   test_settings['install_package_version'] = '1.7.4'
   test_settings['install_version']         = '1.7.4'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -143,7 +143,7 @@ RSpec.configure do |c|
 
       copy_hiera_data_to(host, 'spec/fixtures/hiera/hieradata/')
 
-      modules = ['archive', 'stdlib', 'java', 'datacat', 'java_ks']
+      modules = ['archive', 'stdlib', 'java', 'datacat', 'java_ks', 'sysctl']
 
       dist_module = {
         'Debian' => 'apt',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -143,7 +143,7 @@ RSpec.configure do |c|
 
       copy_hiera_data_to(host, 'spec/fixtures/hiera/hieradata/')
 
-      modules = ['stdlib', 'java', 'datacat', 'java_ks']
+      modules = ['archive', 'stdlib', 'java', 'datacat', 'java_ks']
 
       dist_module = {
         'Debian' => 'apt',

--- a/templates/etc/elasticsearch/log4j2.properties.erb
+++ b/templates/etc/elasticsearch/log4j2.properties.erb
@@ -1,0 +1,74 @@
+status = <%= @logging_level.downcase %>
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+appender.rolling.type = RollingFile
+appender.rolling.name = rolling
+appender.rolling.fileName = ${sys:es.logs}.log
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
+appender.rolling.filePattern = ${sys:es.logs}-%d{yyyy-MM-dd}.log
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+
+rootLogger.level = <%= @logging_level.downcase %>
+rootLogger.appenderRef.console.ref = console
+rootLogger.appenderRef.rolling.ref = rolling
+
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_rolling
+appender.deprecation_rolling.fileName = ${sys:es.logs}_deprecation.log
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
+appender.deprecation_rolling.filePattern = ${sys:es.logs}_deprecation-%i.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 1GB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 4
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
+logger.deprecation.additivity = false
+
+appender.index_search_slowlog_rolling.type = RollingFile
+appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
+appender.index_search_slowlog_rolling.fileName = ${sys:es.logs}_index_search_slowlog.log
+appender.index_search_slowlog_rolling.layout.type = PatternLayout
+appender.index_search_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
+appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs}_index_search_slowlog-%d{yyyy-MM-dd}.log
+appender.index_search_slowlog_rolling.policies.type = Policies
+appender.index_search_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_search_slowlog_rolling.policies.time.interval = 1
+appender.index_search_slowlog_rolling.policies.time.modulate = true
+
+logger.index_search_slowlog_rolling.name = index.search.slowlog
+logger.index_search_slowlog_rolling.level = trace
+logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref = index_search_slowlog_rolling
+logger.index_search_slowlog_rolling.additivity = false
+
+appender.index_indexing_slowlog_rolling.type = RollingFile
+appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
+appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs}_index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
+appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
+appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
+appender.index_indexing_slowlog_rolling.policies.type = Policies
+appender.index_indexing_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_indexing_slowlog_rolling.policies.time.interval = 1
+appender.index_indexing_slowlog_rolling.policies.time.modulate = true
+
+logger.index_indexing_slowlog.name = index.indexing.slowlog.index
+logger.index_indexing_slowlog.level = trace
+logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
+logger.index_indexing_slowlog.additivity = false


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

In addition to handling the log4j2.properties file, this change also adds the necessary 5.x acceptance tests across supported distributions. This adds basic support for 5.x, some additional work may be needed to get addition (i.e., older distros) properly supported (those without an easy way to get a JRE 1.8 environment).