### PR TITLE
OpenBSD doesn't have sysctl vm.max_map_count, so limit its usage

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -126,8 +126,11 @@ class elasticsearch::config {
       }
     }
 
-    sysctl { 'vm.max_map_count':
-      value => 262144,
+    # Other OS than Linux may not have that sysctl
+    if $::kernel == 'Linux' {
+      sysctl { 'vm.max_map_count':
+        value => 262144,
+      }
     }
 
   } elsif ( $elasticsearch::ensure == 'absent' ) {


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)

OpenBSD doesn't have sysctl vm.max_map_count, so limit its usage
to Linux kernels.

This prevents warning messages for me, since on OpenBSD, this sysctl is not there, and looking at metadata.json, there are only Linux systems listed, so I decided to limit that sysctl to the ::kernel 
fact that it is only issued on Linux systems.

Let me know if that is fine, or if other tweaks/enhancements to it are required.