### PR TITLE
Remove ES_HEAP_SIZE check for Elasticsearch 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## x.x.x (Month Day, Year)
+
+### Summary
+
+#### Features
+
+#### Bugfixes
+* Removed ES_HEAP_SIZE check in init scripts for Elasticsearch 5.x
+
+#### Changes
+
+#### Testing changes
+
 ## 0.15.0 (November 17, 2016)
 
 ### Summary

--- a/files/etc/init.d/elasticsearch.Debian.erb
+++ b/files/etc/init.d/elasticsearch.Debian.erb
@@ -134,11 +134,6 @@ case "$1" in
   start)
 	checkJava
 
-	if [ -n "$MAX_LOCKED_MEMORY" -a -z "$ES_HEAP_SIZE" ]; then
-		log_failure_msg "MAX_LOCKED_MEMORY is set - ES_HEAP_SIZE must also be set"
-		exit 1
-	fi
-
 	log_daemon_msg "Starting $DESC"
 
 	pid=`pidofproc -p $PID_FILE elasticsearch`

--- a/files/etc/init.d/elasticsearch.RedHat.erb
+++ b/files/etc/init.d/elasticsearch.RedHat.erb
@@ -70,10 +70,6 @@ start() {
     checkJava
     [ -x $exec ] || exit 5
     [ -f $CONF_FILE ] || exit 6
-    if [ -n "$MAX_LOCKED_MEMORY" -a -z "$ES_HEAP_SIZE" ]; then
-        echo "MAX_LOCKED_MEMORY is set - ES_HEAP_SIZE must also be set"
-        return 7
-    fi
     if [ -n "$MAX_OPEN_FILES" ]; then
         ulimit -n $MAX_OPEN_FILES
     fi

--- a/files/etc/init.d/elasticsearch.SLES.erb
+++ b/files/etc/init.d/elasticsearch.SLES.erb
@@ -69,10 +69,6 @@ start() {
     checkJava
     [ -x $EXE ] || exit 5
     [ -f $CONF_FILE ] || exit 6
-    if [ -n "$MAX_LOCKED_MEMORY" -a -z "$ES_HEAP_SIZE" ]; then
-        echo "MAX_LOCKED_MEMORY is set - ES_HEAP_SIZE must also be set"
-        return 7
-    fi
     if [ -n "$MAX_OPEN_FILES" ]; then
         ulimit -n $MAX_OPEN_FILES
     fi


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

The init scripts can be less stringent about some checks now that Elasticsearch 5.x does not set the heap through this environment variable.

Related to #738