### PR TITLE
Add java_home parameter for correct plugin execution #619

### DIFF
--- a/lib/puppet/provider/elastic_plugin.rb
+++ b/lib/puppet/provider/elastic_plugin.rb
@@ -209,6 +209,10 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
 
     env_vars['ES_JAVA_OPTS'] = env_vars['ES_JAVA_OPTS'].join(' ')
 
+    if !@resource[:java_home].nil?
+      env_vars['JAVA_HOME'] = @resource[:java_home]
+    end
+
     env_vars.each do |env_var, value|
       saved_vars[env_var] = ENV[env_var]
       ENV[env_var] = value

--- a/lib/puppet/provider/elastic_plugin.rb
+++ b/lib/puppet/provider/elastic_plugin.rb
@@ -155,6 +155,10 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
     es_save = ENV['ES_INCLUDE']
     java_save = ENV['JAVA_HOME']
 
+    if @resource[:java_home]
+      ENV['JAVA_HOME'] = @resource[:java_home]
+    end
+
     os = Facter.value('osfamily')
     if os == 'OpenBSD'
       ENV['JAVA_HOME'] = javapathhelper('-h', 'elasticsearch').chomp
@@ -209,7 +213,7 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
 
     env_vars['ES_JAVA_OPTS'] = env_vars['ES_JAVA_OPTS'].join(' ')
 
-    if !@resource[:java_home].nil?
+    if @resource[:java_home]
       env_vars['JAVA_HOME'] = @resource[:java_home]
     end
 

--- a/lib/puppet/type/elasticsearch_plugin.rb
+++ b/lib/puppet/type/elasticsearch_plugin.rb
@@ -32,4 +32,7 @@ Puppet::Type.newtype(:elasticsearch_plugin) do
     desc 'Override name of the directory created for the plugin'
   end
 
+  newparam(:java_home) do
+    desc 'Override the JAVA_HOME path'
+  end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -375,6 +375,7 @@ class elasticsearch(
   $plugindir                      = $elasticsearch::params::plugindir,
   $java_install                   = false,
   $java_package                   = undef,
+  $java_home                      = undef,
   $manage_repo                    = false,
   $repo_version                   = undef,
   $repo_priority                  = undef,
@@ -476,6 +477,10 @@ class elasticsearch(
 
   # java install validation
   validate_bool($java_install)
+
+  if ($java_home != undef) {
+    validate_absolute_path($java_home)
+  }
 
   validate_bool(
     $manage_repo,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,10 @@
 # [*logdir*]
 #   Use different directory for logging
 #
+# [*java_home*]
+#  Optional JAVA_HOME path to be added. Required if JAVA_HOME is not set at puppet execution
+#  Defaults to: undef
+#
 # [*java_install*]
 #  Install java which is required for Elasticsearch.
 #  Defaults to: false

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -165,6 +165,7 @@ define elasticsearch::plugin(
     proxy       => $_proxy,
     plugin_dir  => $::elasticsearch::plugindir,
     plugin_path => $module_dir,
+    java_home   => $::elasticsearch::java_home,
   } ->
   file { "${elasticsearch::plugindir}/${_module_dir}":
     ensure  => $_file_ensure,

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -142,6 +142,7 @@ define elasticsearch::service::init(
         'ES_GROUP' => $elasticsearch::elasticsearch_group,
         'MAX_OPEN_FILES' => '65536',
       }
+
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [ ] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [ ] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)

Hello, this is a contribution to being able to solve #619.

It is not the best solution, since I wanted somehow pass ALL the env variables, not just the JAVA_HOME (e.g. init_defaults hashmap).

But things start to become complex as init_defaults are merged for hiera support and a plugin is installed per node (and potentially, a different init_defaults per instance).

This is the simpler solution to let anyone using puppet agents with NO JAVA_HOME defined to run and install plugins.

I am proceeding asking for the CLA to my company.

Please review and suggest other fixes/changes on that.