### PR TITLE
Add deprecation log feature

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -58,6 +58,15 @@
 #   Default logging level for Elasticsearch.
 #   Defaults to: INFO
 #
+# [*deprecation_logging*]
+#   Wheter to enable deprecation logging. If enabled, deprecation logs will be
+#   saved to ${cluster.name}_deprecation.log in the elastic search log folder.
+#   Default value: false
+#
+# [*deprecation_logging_level*]
+#   Default deprecation logging level for Elasticsearch.
+#   Defaults to: DEBUG
+#
 # [*init_defaults*]
 #   Defaults file content in hash representation
 #
@@ -152,6 +161,8 @@ define elasticsearch::instance(
   $logging_config                = undef,
   $logging_template              = undef,
   $logging_level                 = $elasticsearch::default_logging_level,
+  $deprecation_logging           = false,
+  $deprecation_logging_level     = 'DEBUG',
   $service_flags                 = undef,
   $init_defaults                 = undef,
   $init_defaults_file            = undef,

--- a/spec/defines/005_elasticsearch_instance_spec.rb
+++ b/spec/defines/005_elasticsearch_instance_spec.rb
@@ -421,6 +421,34 @@ describe 'elasticsearch::instance', :type => 'define' do
         it { should contain_file('/etc/elasticsearch/es-01/logging.yml').with(:source => 'puppet:///path/to/logging.yml', :content => nil) }
       end
 
+      context 'deprecation logging' do
+        let :params do {
+          :deprecation_logging => true
+        } end
+
+        it { should contain_file('/etc/elasticsearch/es-01/logging.yml').with_content(/^logger.deprecation: DEBUG, deprecation_log_file$/).with(:source=> nil) }
+        it { should contain_file('/etc/elasticsearch/es-01/logging.yml')
+          .with_content(
+            /deprecation_log_file:$/,
+            /type: dailyRollingFile$/,
+            /file: ${path.logs}\/\${cluster.name}_deprecation.log$/,
+            /datePattern: "'.'yyyy-MM-dd"$/,
+            /layout:$/,
+            /type: pattern$/,
+            /conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"$/
+          ).with(:source=>nil)
+        }
+      end
+
+      context 'deprecation logging level' do
+        let :params do {
+          :deprecation_logging => true,
+          :deprecation_logging_level => 'INFO'
+        } end
+
+        it { should contain_file('/etc/elasticsearch/es-01/logging.yml').with_content(/^logger.deprecation: INFO, deprecation_log_file$/).with(:source=> nil) }
+      end
+
     end
 
     describe 'rollingFile apender' do

--- a/templates/etc/elasticsearch/logging.yml.erb
+++ b/templates/etc/elasticsearch/logging.yml.erb
@@ -14,6 +14,10 @@ rootLogger: <%= @logging_level %>, console, file
 logger.<%= key %>: <%= value %>
 <% end %>
 
+<% if @deprecation_logging -%>
+logger.deprecation: <%= @deprecation_logging_level %>, deprecation_log_file
+<% end -%>
+
 # -------------------------------------------------------------------------------
 
 additivity:
@@ -55,3 +59,13 @@ appender:
     layout:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+<% if @deprecation_logging -%>
+  deprecation_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_deprecation.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+<% end %>


### PR DESCRIPTION
Currently it's not possible to enable the deprecation log, because the
logging template is missing the necessary appender.

This commit will add two new parameters to enable deprecation logging
and to specify a logging level.
The boolean parameter `deprecation_logging` enables deprecation
loggging if set to true.
The string parameter `deprecation_logging_level` specifies the desired
logging level for the deprecation log.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [ ] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [ ] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
