### PR TITLE
Remove chaining between ::pin and ::repo resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -657,11 +657,6 @@ class elasticsearch(
       }
     }
 
-    if defined(Class['elasticsearch::package::pin']) {
-      Class['elasticsearch::package::pin']
-      -> Class['elasticsearch::repo']
-    }
-
   }
 
   #### Manage relationships

--- a/spec/classes/005_elasticsearch_repo_spec.rb
+++ b/spec/classes/005_elasticsearch_repo_spec.rb
@@ -21,19 +21,6 @@ describe 'elasticsearch', :type => 'class' do
         default_params
       end
 
-      context 'ordered with package pinning' do
-
-        let :params do
-          default_params
-        end
-
-        it { should contain_class(
-          'elasticsearch::package::pin'
-        ).that_comes_before(
-          'Class[elasticsearch::repo]'
-        ) }
-      end
-
       context "Use anchor type for ordering" do
 
         let :params do


### PR DESCRIPTION
This fixes #773 

When pinning the package, the resource chaining between the `Class['elasticsearch::package::pin']
` and `Class['elasticsearch::repo']` causes the following dependency cycle:

```
(File_line[versionlock.list-0:elasticsearch-2.4.2-1.noarch] => Yum::Versionlock[0:elasticsearch-2.4.2-1.noarch] => Class[Elasticsearch::Package::Pin] => Class[Elasticsearch::Repo] => Yumrepo[elasticsearch] => Package[yum-plugin-versionlock] => Yum::Plugin[versionlock] => Class[Yum::Plugin::Versionlock] => Yum::Versionlock[0:elasticsearch-2.4.2-1.noarch] => File_line[versionlock.list-0:elasticsearch-2.4.2-1.noarch])
```
*This has only been tested on CentOS7 - I wasn't able to get the acceptance testing running locally*

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
