### PR TITLE
manifests: keep homedir lib directory owned by root, not elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Bugfixes
 * Fixed case in which index template could prepend an additional 'index.' to index settings.
 * Fixed a case in which dependency cycles could arise when pinning packages on CentOS.
+* No longer recursively change the Elasticsearch home directory's lib/ to the elasticsearch user.
 
 #### Changes
 * sysctl settings are no longer managed by the thias/sysctl module.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,8 +56,8 @@ class elasticsearch::config {
         mode   => 'o+Xr';
       "${elasticsearch::homedir}/lib":
         ensure  => 'directory',
-        group   => $elasticsearch::elasticsearch_group,
-        owner   => $elasticsearch::elasticsearch_user,
+        group   => '0',
+        owner   => 'root',
         recurse => true;
       $elasticsearch::params::homedir:
         ensure => 'directory',


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Resolves #775 