### PR TITLE
Leave Shield/X-Pack configs in /etc/elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Changes
 * sysctl settings are no longer managed by the thias/sysctl module.
 * Calls to `elasticsearch -version` in elasticsearch::plugin code replaced with native Puppet code to resolve Elasticsearch package version. Should improve resiliency when managing plugins.
+* Shield and X-Pack configuration files are stored in /etc/elasticsearch instead of /usr/share/elasticsearch.
 
 #### Testing changes
 

--- a/lib/puppet/provider/elastic_parsedfile.rb
+++ b/lib/puppet/provider/elastic_parsedfile.rb
@@ -1,17 +1,11 @@
 require 'puppet/provider/parsedfile'
 
 class Puppet::Provider::ElasticParsedFile < Puppet::Provider::ParsedFile
-
-  def self.shield_config val
-    @default_target ||= case Facter.value('osfamily')
-      when 'OpenBSD'
-        "/usr/local/elasticsearch/shield/#{val}"
-      else
-        "/usr/share/elasticsearch/shield/#{val}"
-      end
+  def self.shield_config(val)
+    @default_target ||= "/etc/elasticsearch/shield/#{val}"
   end
 
-  def self.xpack_config val
+  def self.xpack_config(val)
     @default_target ||= "/etc/elasticsearch/x-pack/#{val}"
   end
 end

--- a/lib/puppet/provider/elastic_plugin.rb
+++ b/lib/puppet/provider/elastic_plugin.rb
@@ -115,12 +115,7 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
 
   def create
     commands = []
-    if is2x?
-      commands << "-Des.path.conf=#{homedir}"
-      if @resource[:proxy]
-        commands += proxy_args(@resource[:proxy])
-      end
-    end
+    commands += proxy_args(@resource[:proxy]) if is2x? and @resource[:proxy]
     commands << 'install'
     commands << '--batch' if batch_capable?
     commands += is1x? ? install1x : install2x
@@ -171,21 +166,18 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
     _vendor, _plugin, version = plugin_name.split('/')
     return es_version if is2x? && version.nil?
     return version.scan(/\d+\.\d+\.\d+(?:\-\S+)?/).first unless version.nil?
-    return false
+    false
   end
 
   # Run a command wrapped in necessary env vars
   def with_environment(&block)
     env_vars = {
-      'ES_JAVA_OPTS' => [],
+      'ES_JAVA_OPTS' => []
     }
     saved_vars = {}
 
-    if not is2x?
-      env_vars['ES_JAVA_OPTS'] << "-Des.path.conf=#{homedir}"
-      if @resource[:proxy]
-        env_vars['ES_JAVA_OPTS'] += proxy_args(@resource[:proxy])
-      end
+    if !is2x? and @resource[:proxy]
+      env_vars['ES_JAVA_OPTS'] += proxy_args(@resource[:proxy])
     end
 
     env_vars['ES_JAVA_OPTS'] = env_vars['ES_JAVA_OPTS'].join(' ')
@@ -201,7 +193,6 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
       ENV[env_var] = value
     end
 
-    return ret
+    ret
   end
-
 end

--- a/lib/puppet/provider/elastic_user_command.rb
+++ b/lib/puppet/provider/elastic_user_command.rb
@@ -1,6 +1,6 @@
 class Puppet::Provider::ElasticUserCommand < Puppet::Provider
 
-  attr_accessor :command_arguments, :homedir
+  attr_accessor :homedir
 
   def self.homedir
     @homedir ||= case Facter.value('osfamily')
@@ -11,13 +11,8 @@ class Puppet::Provider::ElasticUserCommand < Puppet::Provider
                  end
   end
 
-  def self.command_arguments
-    @command_arguments || []
-  end
-
-  def self.command_with_path args
-    args = [args] unless args.is_a? Array
-    users_cli(args + command_arguments)
+  def self.command_with_path(args)
+    users_cli(args.is_a?(Array) ? args : [args])
   end
 
   def self.fetch_users

--- a/lib/puppet/provider/elasticsearch_user/esusers.rb
+++ b/lib/puppet/provider/elasticsearch_user/esusers.rb
@@ -4,13 +4,11 @@ Puppet::Type.type(:elasticsearch_user).provide(
   :esusers,
   :parent => Puppet::Provider::ElasticUserCommand
 ) do
-  desc "Provider for Shield file (esusers) user resources."
+  desc 'Provider for Shield file (esusers) user resources.'
 
   has_feature :manages_plaintext_passwords
 
   mk_resource_methods
-
-  @command_arguments = ["--default.path.conf=#{homedir}"]
 
   commands :users_cli => "#{homedir}/bin/shield/esusers"
   commands :es => "#{homedir}/bin/elasticsearch"

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -430,15 +430,10 @@ define elasticsearch::instance(
     }
 
     if $security_plugin != undef {
-      $_security_source = $security_plugin ? {
-        'shield' => $elasticsearch::params::homedir,
-        'x-pack' => $elasticsearch::configdir,
-      }
-
       file { "${instance_configdir}/${security_plugin}":
         ensure  => 'directory',
         mode    => '0644',
-        source  => "${_security_source}/${security_plugin}",
+        source  => "${elasticsearch::configdir}/${security_plugin}",
         recurse => 'remote',
         owner   => 'root',
         group   => '0',


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Going forward, Elasticsearch's `plugin` command can't be modified to install plugin configs outside of the `/etc/elasticsearch/` directory. This change modifies the plugin command to restore the default behavior (backwards incompatible).