### PR TITLE
plugin install: make instances parameter optional

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -97,8 +97,8 @@ define elasticsearch::plugin(
 
   case $ensure {
     'installed', 'present': {
-      if empty($instances) {
-        fail('no $instances defined')
+      if empty($instances) and $elasticsearch::restart_plugin_change {
+        fail('no $instances defined, even tho `restart_plugin_change` is set!')
       }
 
       $_file_ensure = 'directory'


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

When we explicitly disable the restart, then $instances isn't used (and
hence, needed) either. Make it optional.
This pull request addresses #820