### PR TITLE
Fix $LOAD_PATH for puppet_x library, point to relative lib path

### DIFF
--- a/lib/puppet/provider/elastic_plugin.rb
+++ b/lib/puppet/provider/elastic_plugin.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+
 require 'uri'
 require 'puppet_x/elastic/es_versioning'
 require 'puppet_x/elastic/plugin_name'

--- a/lib/puppet/provider/elastic_yaml.rb
+++ b/lib/puppet/provider/elastic_yaml.rb
@@ -1,4 +1,5 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+
 require 'puppet/provider/elastic_parsedfile'
 require 'puppet/util/package'
 require 'puppet_x/elastic/hash'

--- a/lib/puppet/provider/elasticsearch_index/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_index/ruby.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..', '..'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
 require 'puppet/provider/elastic_rest'
 

--- a/lib/puppet/provider/elasticsearch_service_file/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_service_file/ruby.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..","..",".."))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
 require 'pathname'
 require 'puppet/util/filetype'

--- a/lib/puppet/provider/elasticsearch_template/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_template/ruby.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..', '..'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
 require 'puppet/provider/elastic_rest'
 

--- a/lib/puppet/type/elasticsearch_index.rb
+++ b/lib/puppet/type/elasticsearch_index.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
 require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_implode'

--- a/lib/puppet/type/elasticsearch_pipeline.rb
+++ b/lib/puppet/type/elasticsearch_pipeline.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
 require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_implode'

--- a/lib/puppet/type/elasticsearch_template.rb
+++ b/lib/puppet/type/elasticsearch_template.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
 require 'puppet/file_serving/content'
 require 'puppet/file_serving/metadata'


### PR DESCRIPTION
The LOAD_PATH has most of the time an wrong relative path to the puppet module libs directory. 

Before they pointed to the whole puppet module directory, which breaks the require statements. Results in something like: require '<puppet_module>/puppet/...'.
They should point to the lib directory instead of the module, to ensure require loads works fine: 
require '<puppet_module>/lib/..'