### PR TITLE
Reset potentially inherited defaults (since the mode is not always sp…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,13 @@ class elasticsearch::config {
     cwd  => '/',
   }
 
+  # Reset potentially inherited defaults (since the mode is not always specified in below items, for example "${elasticsearch::homedir}/lib" )
+  File {
+      owner       => undef,
+      group       => undef,
+      mode        => undef,
+  }
+
   if ( $elasticsearch::ensure == 'present' ) {
 
     file {


### PR DESCRIPTION
Reset potentially inherited defaults (since the mode is not always specified in below items

For example "${elasticsearch::homedir}/lib" was stripped of 'other' permissions, so my Elasticsearch was unable to start