### PR TITLE
Add support for setting NPROC value in systemd unit

### DIFF
--- a/files/etc/init.d/elasticsearch.systemd.erb
+++ b/files/etc/init.d/elasticsearch.systemd.erb
@@ -30,7 +30,7 @@ StandardError=inherit
 # Specifies the maximum file descriptor number that can be opened by this process
 LimitNOFILE=<%= @resource[:nofile] %>
 
-# Specifies the maximum number of threads that can be opened by this process
+# Specifies the maximum number of processes
 LimitNPROC=<%= @resource[:nproc] %>
 
 # Specifies the maximum number of bytes of memory that may be locked into RAM

--- a/files/etc/init.d/elasticsearch.systemd.erb
+++ b/files/etc/init.d/elasticsearch.systemd.erb
@@ -30,6 +30,9 @@ StandardError=inherit
 # Specifies the maximum file descriptor number that can be opened by this process
 LimitNOFILE=<%= @resource[:nofile] %>
 
+# Specifies the maximum number of threads that can be opened by this process
+LimitNPROC=<%= @resource[:nproc] %>
+
 # Specifies the maximum number of bytes of memory that may be locked into RAM
 # Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${path.env}

--- a/lib/puppet/type/elasticsearch_service_file.rb
+++ b/lib/puppet/type/elasticsearch_service_file.rb
@@ -66,6 +66,10 @@ Puppet::Type.newtype(:elasticsearch_service_file) do
     desc 'Service NOFILE ulimit.'
   end
 
+  newparam(:nproc) do
+    desc 'Service NPROC ulimit.'
+  end
+
   newparam(:package_name) do
     desc 'Name of the system Elasticsearch package.'
   end

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -132,9 +132,10 @@ define elasticsearch::service::systemd(
         }
       }
       $init_defaults_pre_hash = {
-        'ES_USER' => $elasticsearch::elasticsearch_user,
-        'ES_GROUP' => $elasticsearch::elasticsearch_group,
+        'ES_USER'        => $elasticsearch::elasticsearch_user,
+        'ES_GROUP'       => $elasticsearch::elasticsearch_group,
         'MAX_OPEN_FILES' => '65536',
+        'MAX_THREADS'    => '2048',
       }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
@@ -162,6 +163,12 @@ define elasticsearch::service::systemd(
         $memlock = undef
       }
 
+      if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_THREADS')) {
+        $nproc = $new_init_defaults['MAX_THREADS']
+      }else{
+        $nproc = '2048'
+      }
+
       elasticsearch_service_file { "${elasticsearch::params::systemd_service_path}/elasticsearch-${name}.service":
         ensure            => $ensure,
         content           => file($init_template),
@@ -171,6 +178,7 @@ define elasticsearch::service::systemd(
         instance          => $name,
         memlock           => $memlock,
         nofile            => $nofile,
+        nproc             => $nproc,
         package_name      => $elasticsearch::package_name,
         pid_dir           => $elasticsearch::pid_dir,
         user              => $elasticsearch::elasticsearch_user,

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -135,7 +135,7 @@ define elasticsearch::service::systemd(
         'ES_USER'        => $elasticsearch::elasticsearch_user,
         'ES_GROUP'       => $elasticsearch::elasticsearch_group,
         'MAX_OPEN_FILES' => '65536',
-        'MAX_THREADS'    => '2048',
+        'MAX_THREADS'    => '4096',
       }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
@@ -166,7 +166,7 @@ define elasticsearch::service::systemd(
       if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_THREADS')) {
         $nproc = $new_init_defaults['MAX_THREADS']
       }else{
-        $nproc = '2048'
+        $nproc = '4096'
       }
 
       elasticsearch_service_file { "${elasticsearch::params::systemd_service_path}/elasticsearch-${name}.service":

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -108,7 +108,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_GROUP 'elasticsearch'",
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
-                "set MAX_OPEN_FILES '65536'"
+                "set MAX_OPEN_FILES '65536'",
+                "set MAX_THREADS '2048'"
               ].join("\n") << "\n",
               :before => 'Service[elasticsearch-instance-es-01]'
           ) }
@@ -158,7 +159,8 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_GROUP 'elasticsearch'",
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
-                "set MAX_OPEN_FILES '65536'"
+                "set MAX_OPEN_FILES '65536'",
+                "set MAX_THREADS '2048'"
               ].join("\n") << "\n"
             )}
             it { should contain_augeas(

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -109,7 +109,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
                 "set MAX_OPEN_FILES '65536'",
-                "set MAX_THREADS '2048'"
+                "set MAX_THREADS '4096'"
               ].join("\n") << "\n",
               :before => 'Service[elasticsearch-instance-es-01]'
           ) }
@@ -160,7 +160,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
                 "set ES_HOME '/usr/share/elasticsearch'",
                 "set ES_USER 'elasticsearch'",
                 "set MAX_OPEN_FILES '65536'",
-                "set MAX_THREADS '2048'"
+                "set MAX_THREADS '4096'"
               ].join("\n") << "\n"
             )}
             it { should contain_augeas(

--- a/spec/unit/type/elasticsearch_service_file_spec.rb
+++ b/spec/unit/type/elasticsearch_service_file_spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Type.type(:elasticsearch_service_file) do
       :homedir,
       :memlock,
       :nofile,
+      :nproc,
       :package_name,
       :pid_dir,
       :user


### PR DESCRIPTION
As per #836, Elasticsearch 5 fails to start on CentOS 7 due to 'max number of threads is too low'. 

This PR adds support for over-riding the 'NPROC' value.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
