### PR TITLE
Under systemd elasticsearch should start quiet

### DIFF
--- a/files/etc/init.d/elasticsearch.systemd.erb
+++ b/files/etc/init.d/elasticsearch.systemd.erb
@@ -15,7 +15,7 @@ Group=<%= @resource[:group] %>
 ExecStartPre=-/usr/share/elasticsearch/bin/elasticsearch-systemd-pre-exec
 
 ExecStart=/usr/share/elasticsearch/bin/elasticsearch \
-                                                -p <%= @resource[:pid_dir] %>/elasticsearch-<%= @resource[:instance] %>.pid \
+                                                -p <%= @resource[:pid_dir] %>/elasticsearch-<%= @resource[:instance] %>.pid --quiet \
                                                 <%= opt_flags.join(' ') %>
 
 # StandardOutput is configured to redirect to journalctl since


### PR DESCRIPTION
Don't understood where are defaults  ```opt_flags```  ( ```-Edefault.path.conf=${CONF_DIR} -Edefault.path.data=${DATA_DIR} -Edefault.path.logs=${LOG_DIR}``` ). 

 