### PR TITLE
systemd: restart service on failure

### DIFF
--- a/files/etc/init.d/elasticsearch.systemd.erb
+++ b/files/etc/init.d/elasticsearch.systemd.erb
@@ -18,6 +18,8 @@ ExecStart=/usr/share/elasticsearch/bin/elasticsearch \
                                                 -p <%= @resource[:pid_dir] %>/elasticsearch-<%= @resource[:instance] %>.pid \
                                                 <%= opt_flags.join(' ') %>
 
+Restart=on-failure
+
 # StandardOutput is configured to redirect to journalctl since
 # some error messages may be logged in standard output before
 # elasticsearch logging system is initialized. Elasticsearch


### PR DESCRIPTION
Restart=on-failure option will tell systemd to restart the service if it exited with non-zero exit code.

See [Restart](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=) option in systemd manual. In particular, it recommends the following:

> Setting this to on-failure is the recommended choice for long-running services, in order to increase reliability by attempting automatic recovery from errors.

The default value for [StartLimitIntervalSec](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=) will limit service to be restarted not more than 5 times within 10 seconds.

There is also a possibility to set this parameter optionally, but I think it would be a good default behavior.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
