### PR TITLE
export ES_PATH_CONF env variable in Red Hat init script

### DIFF
--- a/files/etc/init.d/elasticsearch.RedHat.erb
+++ b/files/etc/init.d/elasticsearch.RedHat.erb
@@ -53,6 +53,7 @@ export ES_JAVA_OPTS
 export ES_JVM_OPTIONS
 export JAVA_HOME
 export ES_INCLUDE
+export ES_PATH_CONF
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
This minor patch exports the ES_PATH_CONF variable inside the Red Hat init script to solve this problem:

`[root@localhost ~]# /etc/init.d/elasticsearch-es-01  start
Starting elasticsearch-es-01: ES_PATH_CONF must be set to the configuration path
                                                           [FAILED]
`

Somewhat similar to #877 but related to the starting of services, not plugins.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
