### PR TITLE
option to set JAVA_HOME for elasticsearch plugins

### DIFF
--- a/lib/puppet/provider/elastic_plugin.rb
+++ b/lib/puppet/provider/elastic_plugin.rb
@@ -210,12 +210,17 @@ class Puppet::Provider::ElasticPlugin < Puppet::Provider
   def with_environment(&block)
     env_vars = {
       'ES_JAVA_OPTS' => @resource[:java_opts],
-      'ES_PATH_CONF' => @resource[:configdir]
+      'ES_PATH_CONF' => @resource[:configdir],
+      'JAVA_HOME'    => @resource[:java_home]
     }
     saved_vars = {}
 
     if !is2x? and @resource[:proxy]
       env_vars['ES_JAVA_OPTS'] += proxy_args(@resource[:proxy])
+    end
+
+    if @resource[:java_home].nil? or @resource[:java_home] == ''
+      env_vars.delete('JAVA_HOME')
     end
 
     env_vars['ES_JAVA_OPTS'] = env_vars['ES_JAVA_OPTS'].join(' ')

--- a/lib/puppet/type/elasticsearch_plugin.rb
+++ b/lib/puppet/type/elasticsearch_plugin.rb
@@ -25,6 +25,10 @@ Puppet::Type.newtype(:elasticsearch_plugin) do
     defaultto []
   end
 
+  newparam(:java_home) do
+    desc 'Optional string to set the environment variable JAVA_HOME.'
+  end
+
   newparam(:url) do
     desc 'Url of the package'
   end

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -24,6 +24,9 @@
 # @param java_opts
 #   Array of Java options to be passed to `ES_JAVA_OPTS`
 #
+# @param java_home
+#   Path to JAVA_HOME, if Java is installed in a non-standard location.
+#
 # @param module_dir
 #   Directory name where the module has been installed
 #   This is automatically generated based on the module name
@@ -59,6 +62,7 @@ define elasticsearch::plugin (
   Stdlib::Absolutepath           $configdir      = $elasticsearch::configdir,
   Variant[String, Array[String]] $instances      = [],
   Array[String]                  $java_opts      = [],
+  Optional[Stdlib::Absolutepath] $java_home      = undef,
   Optional[String]               $module_dir     = undef,
   Optional[String]               $proxy_host     = undef,
   Optional[String]               $proxy_password = undef,
@@ -132,6 +136,7 @@ define elasticsearch::plugin (
     configdir                  => $configdir,
     elasticsearch_package_name => $elasticsearch::package_name,
     java_opts                  => $java_opts,
+    java_home                  => $java_home,
     source                     => $file_source,
     url                        => $url,
     proxy                      => $_proxy,

--- a/spec/unit/provider/elasticsearch_plugin/shared_examples.rb
+++ b/spec/unit/provider/elasticsearch_plugin/shared_examples.rb
@@ -132,6 +132,25 @@ shared_examples 'plugin provider' do |version|
       end
     end
 
+    describe 'java_home' do
+      it 'sets the JAVA_HOME env var' do
+        resource[:java_home] = '/opt/foo'
+        expect(provider.with_environment do
+          ENV['JAVA_HOME']
+        end).to eq('/opt/foo')
+      end
+    end
+
+    describe 'java_home unset' do
+      existing_java_home = ENV['JAVA_HOME']
+      it 'does not change JAVA_HOME env var' do
+        resource[:java_home] = ''
+        expect(provider.with_environment do
+          ENV['JAVA_HOME']
+        end).to eq(existing_java_home)
+      end
+    end
+
     describe 'plugin_name' do
       let(:resource_name) { 'appbaseio/dejaVu' }
 

--- a/spec/unit/type/elasticsearch_plugin_spec.rb
+++ b/spec/unit/type/elasticsearch_plugin_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:elasticsearch_plugin) do
 
   describe 'input validation' do
     describe 'when validating attributes' do
-      %i[configdir java_opts name source url proxy].each do |param|
+      %i[configdir java_opts java_home name source url proxy].each do |param|
         it "should have a #{param} parameter" do
           expect(described_class.attrtype(param)).to eq(:param)
         end


### PR DESCRIPTION
This is an adaption of PR #754 that's recently rebased, and basically piggy backs off the existing Environment modification code you've got in the plugin provider to also allow overriding JAVA_HOME, for those non-standard Java installs.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
