### PR TITLE
Stop default service starting

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,8 +69,6 @@ class elasticsearch::config {
         ensure => 'absent';
       '/etc/elasticsearch/log4j2.properties':
         ensure => 'absent';
-      '/etc/init.d/elasticsearch':
-        ensure => 'absent';
     }
 
     if $elasticsearch::pid_dir {
@@ -98,7 +96,13 @@ class elasticsearch::config {
     if ($elasticsearch::service_provider == 'systemd') {
       # Mask default unit (from package)
       service { 'elasticsearch' :
+        ensure => false,
         enable => 'mask',
+      }
+    } else {
+      service { 'elasticsearch':
+        ensure => false,
+        enable => false,
       }
     }
 

--- a/spec/acceptance/002_class_spec.rb
+++ b/spec/acceptance/002_class_spec.rb
@@ -29,6 +29,11 @@ describe '::elasticsearch' do
       end
     end
 
+    describe service('elasticsearch') do
+      it { should_not be_running }
+      it { should_not be_enabled }
+    end
+
     describe service(test_settings['service_name_a']) do
       it { should be_enabled }
       it { should be_running }

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -61,7 +61,7 @@ describe 'elasticsearch', :type => 'class' do
 
       # Systemd-specific files
       if test_pid == true
-        it { should contain_service('elasticsearch').with(:enable => 'mask') }
+        it { should contain_service('elasticsearch').with(:ensure => false).with(:enable => 'mask') }
         it { should contain_file('/usr/lib/tmpfiles.d/elasticsearch.conf') }
       end
 
@@ -305,8 +305,6 @@ describe 'elasticsearch', :type => 'class' do
         it { should contain_exec('remove_plugin_dir') }
 
         # file removal from package
-        it { should contain_file('/etc/init.d/elasticsearch')
-          .with(:ensure => 'absent') }
         it { should contain_file('/etc/elasticsearch/elasticsearch.yml')
           .with(:ensure => 'absent') }
         it { should contain_file('/etc/elasticsearch/jvm.options')


### PR DESCRIPTION
Fixes #924. Stops the default service that is masked from being started by Puppet.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [ ] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)