### PR TITLE
Remove deprecated data_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 #### Fixes
+* Removes deprecated data_provider from metadata.json.
 
 ## 6.3.0 (June 18, 2018)
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,6 @@
   "description": "Module for managing and configuring Elasticsearch nodes",
   "project_page": "https://github.com/elastic/puppet-elasticsearch",
   "issues_url": "https://github.com/elastic/puppet-elasticsearch/issues",
-  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "elastic/elastic_stack",


### PR DESCRIPTION
 Removes the deprecated data_provider => hiera line from metadata.json.
Fixes #947.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [X] Tests pass
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
