### PR TITLE
Replace is_array uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 #### Fixes
+* Resolve deprecation warnings related to use of the deprecated is_array() function.
 
 ## 6.3.0 (June 18, 2018)
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -203,7 +203,7 @@ define elasticsearch::instance (
     # String or array for data dir(s)
     if ($datadir == undef) {
       if ($datadir_instance_directories) {
-        if (is_array($elasticsearch::datadir)) {
+        if $elasticsearch::datadir =~ Array {
           $instance_datadir = array_suffix($elasticsearch::datadir, "/${name}")
         } else {
           $instance_datadir = "${elasticsearch::datadir}/${name}"
@@ -257,7 +257,7 @@ define elasticsearch::instance (
 
     $instance_datadir_config = { 'path.data' => $instance_datadir }
 
-    if(is_array($instance_datadir)) {
+    if $instance_datadir =~ Array {
       $dirs = join($instance_datadir, ' ')
     } else {
       $dirs = $instance_datadir


### PR DESCRIPTION
Resolve the following deprecation warnings from stdlib caused by use of
the is_array() function. Fixes #949.

Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [X] Tests pass
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
