### PR TITLE
Convert hiera.yaml from experiment v4 to v5 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 #### Fixes
+* Convert the hiera.yaml from v4 to v5 format to resolve deprecation warnings.
 
 ## 6.3.0 (June 18, 2018)
 

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,27 +1,18 @@
 ---
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
 hierarchy:
   - name: "Distribution major version"
-    backend: yaml
-    path: "distro/%{facts.os.name}/%{facts.os.release.major}"
-
+    path: "distro/%{facts.os.name}/%{facts.os.release.major}.yaml"
   - name: "Operating system family major version"
-    backend: yaml
-    path: "os/%{facts.os.family}/%{facts.os.release.major}"
-
+    path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
   - name: "Distribution name"
-    backend: yaml
-    path: "distro/%{facts.os.name}"
-
+    path: "distro/%{facts.os.name}.yaml"
   - name: "Operating system family"
-    backend: yaml
-    path: "os/%{facts.os.family}"
-
+    path: "os/%{facts.os.family}.yaml"
   - name: "System kernel"
-    backend: yaml
-    path: "kernel/%{facts.kernel}"
-
+    path: "kernel/%{facts.kernel}.yaml"
   - name: "Default values"
-    backend: yaml
-    path: "common"
+    path: "common.yaml"


### PR DESCRIPTION
See here https://puppet.com/docs/puppet/5.0/hiera_migrate_v4_yaml.html.
I have converted this file to resolve the deprecation warnings seen
during puppet runs.

Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [X] Tests pass
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
