### PR TITLE
Replace is_string uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 * REST-based resources are now coerced to string values to uniformly compare user defined values and Elasticsearch API responses.
 * Resolve deprecation warnings related to use of the deprecated is_array() function.
+* Resolve deprecation warnings related to use of the deprecated is_string() function.
 
 ## 6.3.0 (June 18, 2018)
 

--- a/manifests/license.pp
+++ b/manifests/license.pp
@@ -59,7 +59,7 @@ class elasticsearch::license (
   Optional[Enum['shield', 'x-pack']] $security_plugin         = $elasticsearch::security_plugin,
   Boolean                            $validate_tls            = $elasticsearch::validate_tls,
 ) {
-  if $content != undef and is_string($content) {
+  if $content =~ String {
     $_content = parsejson($content)
   } else {
     $_content = $content

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -66,7 +66,7 @@ define elasticsearch::template (
   Optional[String]                $source                  = undef,
   Boolean                         $validate_tls            = $elasticsearch::validate_tls,
 ) {
-  if $content != undef and is_string($content) {
+  if $content =~ String {
     $_content = parsejson($content)
   } else {
     $_content = $content


### PR DESCRIPTION
Resolve deprecation warnings from stdlib caused by use of the
is_string() function. Fixes #964.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [X] Tests pass
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
