### PR TITLE
Rest resources int datatypes

### DIFF
--- a/lib/puppet/provider/elasticsearch_index/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_index/ruby.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
 require 'puppet/provider/elastic_rest'
 
+require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_to_s'
 
 Puppet::Type.type(:elasticsearch_index).provide(
@@ -10,7 +11,8 @@ Puppet::Type.type(:elasticsearch_index).provide(
   :metadata => :settings,
   :metadata_pipeline => [
     lambda { |data| data['settings'] },
-    lambda { |data| Puppet_X::Elastic.deep_to_s data }
+    lambda { |data| Puppet_X::Elastic.deep_to_s data },
+    lambda { |data| Puppet_X::Elastic.deep_to_i data }
   ],
   :api_uri => '_settings',
   :api_discovery_uri => '_all',

--- a/lib/puppet/provider/elasticsearch_license/shield.rb
+++ b/lib/puppet/provider/elasticsearch_license/shield.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:elasticsearch_license).provide(
   :parent => Puppet::Provider::ElasticREST,
   :metadata => :content,
   :metadata_pipeline => [
-    lambda { |data| Puppet_X::Elastic.deep_to_s data }
+    lambda { |data| Puppet_X::Elastic.deep_to_s data },
+    lambda { |data| Puppet_X::Elastic.deep_to_i data }
   ],
   :api_uri => '_license',
   :query_string => {

--- a/lib/puppet/provider/elasticsearch_license/x-pack.rb
+++ b/lib/puppet/provider/elasticsearch_license/x-pack.rb
@@ -8,7 +8,8 @@ Puppet::Type.type(:elasticsearch_license).provide(
   :parent => Puppet::Provider::ElasticREST,
   :metadata => :content,
   :metadata_pipeline => [
-    lambda { |data| Puppet_X::Elastic.deep_to_s data }
+    lambda { |data| Puppet_X::Elastic.deep_to_s data },
+    lambda { |data| Puppet_X::Elastic.deep_to_i data }
   ],
   :api_uri => '_xpack/license',
   :query_string => {

--- a/lib/puppet/provider/elasticsearch_template/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_template/ruby.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
 require 'puppet/provider/elastic_rest'
 
+require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_to_s'
 
 Puppet::Type.type(:elasticsearch_template).provide(
@@ -10,7 +11,8 @@ Puppet::Type.type(:elasticsearch_template).provide(
   :api_uri => '_template',
   :metadata => :content,
   :metadata_pipeline => [
-    lambda { |data| Puppet_X::Elastic.deep_to_s data }
+    lambda { |data| Puppet_X::Elastic.deep_to_s data },
+    lambda { |data| Puppet_X::Elastic.deep_to_i data }
   ]
 ) do
   desc 'A REST API based provider to manage Elasticsearch templates.'

--- a/lib/puppet/type/elasticsearch_index.rb
+++ b/lib/puppet/type/elasticsearch_index.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
 require 'puppet_x/elastic/asymmetric_compare'
+require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_to_s'
 require 'puppet_x/elastic/elasticsearch_rest_resource'
 
@@ -23,7 +24,7 @@ Puppet::Type.newtype(:elasticsearch_index) do
     end
 
     munge do |value|
-      Puppet_X::Elastic.deep_to_s(value)
+      Puppet_X::Elastic.deep_to_i(Puppet_X::Elastic.deep_to_s(value))
     end
 
     validate do |value|

--- a/lib/puppet/type/elasticsearch_license.rb
+++ b/lib/puppet/type/elasticsearch_license.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
 require 'puppet_x/elastic/asymmetric_compare'
+require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_to_s'
 require 'puppet_x/elastic/elasticsearch_rest_resource'
 
@@ -45,7 +46,7 @@ Puppet::Type.newtype(:elasticsearch_license) do
     end
 
     munge do |value|
-      Puppet_X::Elastic.deep_to_s(value)
+      Puppet_X::Elastic.deep_to_i(Puppet_X::Elastic.deep_to_s(value))
     end
   end
 end # of newtype

--- a/lib/puppet/type/elasticsearch_pipeline.rb
+++ b/lib/puppet/type/elasticsearch_pipeline.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 
+require 'puppet_x/elastic/deep_to_i'
 require 'puppet_x/elastic/deep_to_s'
 require 'puppet_x/elastic/elasticsearch_rest_resource'
 
@@ -22,7 +23,7 @@ Puppet::Type.newtype(:elasticsearch_pipeline) do
     end
 
     munge do |value|
-      Puppet_X::Elastic.deep_to_s(value)
+      Puppet_X::Elastic.deep_to_i(Puppet_X::Elastic.deep_to_s(value))
     end
   end
 end # of newtype

--- a/spec/fixtures/templates/post_6.0.json
+++ b/spec/fixtures/templates/post_6.0.json
@@ -1,5 +1,6 @@
 {
   "index_patterns": [ "logstash-*" ],
+  "version": 123,
   "settings": {
     "index": {
       "refresh_interval": "5s",

--- a/spec/helpers/unit/type/elasticsearch_rest_shared_examples.rb
+++ b/spec/helpers/unit/type/elasticsearch_rest_shared_examples.rb
@@ -63,12 +63,12 @@ shared_examples 'REST API types' do |resource_type, meta_property|
         end.not_to raise_error
       end
 
-      it 'should deeply stringify PSON-like values' do
+      it 'should parse PSON-like values for certain types' do
         expect(described_class.new(
           :name => resource_name,
-          meta_property => { 'key' => { 'value' => 0 } }
+          meta_property => { 'key' => { 'value' => '0', 'other' => true } }
         )[meta_property]).to include(
-          'key' => { 'value' => '0' }
+          'key' => { 'value' => 0, 'other' => 'true' }
         )
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,7 @@ require 'vault'
 
 require_relative 'spec_helper_tls'
 require_relative 'spec_utilities'
+require_relative '../lib/puppet_x/elastic/deep_to_i'
 require_relative '../lib/puppet_x/elastic/deep_to_s'
 
 def f
@@ -31,7 +32,7 @@ RSpec.configure do |c|
                    else
                      JSON.load(File.new('spec/fixtures/templates/post_6.0.json'))
                    end
-    v[:template] = Puppet_X::Elastic.deep_to_s(v[:template])
+    v[:template] = Puppet_X::Elastic.deep_to_i(Puppet_X::Elastic.deep_to_s(v[:template]))
 
     v[:elasticsearch_plugins] = Dir[
       artifact("*#{v[:elasticsearch_full_version]}.zip", ['plugins'])

--- a/spec/unit/provider/elasticsearch_index/ruby_spec.rb
+++ b/spec/unit/provider/elasticsearch_index/ruby_spec.rb
@@ -10,9 +10,9 @@ describe Puppet::Type.type(:elasticsearch_index).provider(:ruby) do
       :provider => :ruby,
       :settings => {
         'index' => {
-          'creation_date' => '1487354196301',
-          'number_of_replicas' => '1',
-          'number_of_shards' => '5',
+          'creation_date' => 1_487_354_196_301,
+          'number_of_replicas' => 1,
+          'number_of_shards' => 5,
           'provided_name' => 'a',
           'routing' => {
             'allocation' => {
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:elasticsearch_index).provider(:ruby) do
           },
           'uuid' => 'vtJrcgyeRviqllRakSlrSw',
           'version' => {
-            'created' => '5020199'
+            'created' => 5_020_199
           }
         }
       }
@@ -69,13 +69,13 @@ describe Puppet::Type.type(:elasticsearch_index).provider(:ruby) do
       :provider => :ruby,
       :settings => {
         'index' => {
-          'creation_date' => '1487354196301',
-          'number_of_replicas' => '1',
-          'number_of_shards' => '5',
+          'creation_date' => 1_487_354_196_301,
+          'number_of_replicas' => 1,
+          'number_of_shards' => 5,
           'provided_name' => 'a',
           'uuid' => 'vtJrcgyeRviqllRakSlrSw',
           'version' => {
-            'created' => '5020199'
+            'created' => 5_020_199
           }
         }
       }
@@ -104,7 +104,7 @@ describe Puppet::Type.type(:elasticsearch_index).provider(:ruby) do
   let(:bare_resource) do
     JSON.dump(
       'index' => {
-        'number_of_replicas' => '0'
+        'number_of_replicas' => 0
       }
     )
   end

--- a/spec/unit/provider/elasticsearch_license/all_spec.rb
+++ b/spec/unit/provider/elasticsearch_license/all_spec.rb
@@ -18,13 +18,13 @@ require_relative '../../../helpers/unit/provider/elasticsearch_rest_shared_examp
             'uid' => 'cbff45e7-c553-41f7-ae4f-9205eabd80xx',
             'type' => 'trial',
             'issue_date' => '2018-02-22T23:12:05.550Z',
-            'issue_date_in_millis' => '1519341125550',
+            'issue_date_in_millis' => 1_519_341_125_550,
             'expiry_date' => '2018-03-24T23:12:05.550Z',
-            'expiry_date_in_millis' => '1521933125550',
-            'max_nodes' => '1000',
+            'expiry_date_in_millis' => 1_521_933_125_550,
+            'max_nodes' => 1_000,
             'issued_to' => 'test',
             'issuer' => 'elasticsearch',
-            'start_date_in_millis' => '1513814400000'
+            'start_date_in_millis' => 1_513_814_400_000
           }
         }
       }
@@ -55,7 +55,7 @@ require_relative '../../../helpers/unit/provider/elasticsearch_rest_shared_examp
         :name => name,
         :settings => {
           'index' => {
-            'number_of_replicas' => '0'
+            'number_of_replicas' => 0
           }
         }
       }

--- a/spec/unit/provider/elasticsearch_template/ruby_spec.rb
+++ b/spec/unit/provider/elasticsearch_template/ruby_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Type.type(:elasticsearch_template).provider(:ruby) do
         'mappings' => {},
         'settings' => {},
         'template' => 'foobar1-*',
-        'order' => '1'
+        'order' => 1
       }
     }
   end
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:elasticsearch_template).provider(:ruby) do
         'mappings' => {},
         'settings' => {},
         'template' => 'foobar2-*',
-        'order' => '2'
+        'order' => 2
       }
     }
   end
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:elasticsearch_template).provider(:ruby) do
 
   let(:bare_resource) do
     JSON.dump(
-      'order' => '0',
+      'order' => 0,
       'aliases' => {},
       'mappings' => {},
       'template' => 'fooindex-*'

--- a/spec/unit/type/elasticsearch_index_spec.rb
+++ b/spec/unit/type/elasticsearch_index_spec.rb
@@ -25,13 +25,13 @@ describe Puppet::Type.type(:elasticsearch_index) do
         let(:is_settings) do
           {
             'index' => {
-              'creation_date' => '1487354196301',
-              'number_of_replicas' => '0',
-              'number_of_shards' => '5',
+              'creation_date' => 1_487_354_196_301,
+              'number_of_replicas' => 0,
+              'number_of_shards' => 5,
               'provided_name' => 'a',
               'uuid' => 'vtjrcgyerviqllrakslrsw',
               'version' => {
-                'created' => '5020199'
+                'created' => 5_020_199
               }
             }
           }
@@ -46,13 +46,13 @@ describe Puppet::Type.type(:elasticsearch_index) do
         let(:is_settings) do
           {
             'index' => {
-              'creation_date' => '1487354196301',
-              'number_of_replicas' => '1',
-              'number_of_shards' => '5',
+              'creation_date' => 1_487_354_196_301,
+              'number_of_replicas' => 1,
+              'number_of_shards' => 5,
               'provided_name' => 'a',
               'uuid' => 'vtjrcgyerviqllrakslrsw',
               'version' => {
-                'created' => '5020199'
+                'created' => 5_020_199
               }
             }
           }

--- a/spec/unit/type/elasticsearch_license_spec.rb
+++ b/spec/unit/type/elasticsearch_license_spec.rb
@@ -37,13 +37,13 @@ describe Puppet::Type.type(:elasticsearch_license) do
               'uid' => 'cbff45e7-c553-41f7-ae4f-9205eabd80xx',
               'type' => 'trial',
               'issue_date' => '2018-02-22T23:12:05.550Z',
-              'issue_date_in_millis' => '1519341125550',
+              'issue_date_in_millis' => 1_519_341_125_550,
               'expiry_date' => '2018-03-24T23:12:05.550Z',
-              'expiry_date_in_millis' => '1521933125550',
-              'max_nodes' => '1000',
+              'expiry_date_in_millis' => 1_521_933_125_550,
+              'max_nodes' => 1_000,
               'issued_to' => 'test',
               'issuer' => 'elasticsearch',
-              'start_date_in_millis' => '1513814400000'
+              'start_date_in_millis' => 1_513_814_400_000
             }
           }
         end

--- a/spec/unit/type/elasticsearch_template_spec.rb
+++ b/spec/unit/type/elasticsearch_template_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:elasticsearch_template) do
           :source => '/example.json'
         )[:content]).to include(
           'template' => 'foobar-*',
-          'order' => '1'
+          'order' => 1
         )
       end
 
@@ -60,13 +60,13 @@ describe Puppet::Type.type(:elasticsearch_template) do
             'index' => { 'number_of_shards' => '3' }
           } }
         )[:content]).to eq(
-          'order' => '0',
+          'order' => 0,
           'aliases' => {},
           'mappings' => {},
           'settings' => {
             'index' => {
-              'number_of_replicas' => '2',
-              'number_of_shards' => '3'
+              'number_of_replicas' => 2,
+              'number_of_shards' => 3
             }
           }
         )
@@ -82,13 +82,13 @@ describe Puppet::Type.type(:elasticsearch_template) do
             }
           }
         )[:content]).to eq(
-          'order' => '0',
+          'order' => 0,
           'aliases' => {},
           'mappings' => {},
           'settings' => {
             'index' => {
-              'number_of_replicas' => '2',
-              'number_of_shards' => '3'
+              'number_of_replicas' => 2,
+              'number_of_shards' => 3
             }
           }
         )


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

The fix for #957 aggressively coerced all values to strings in order to uniformly compare values that get returned from the Elasticsearch API. While nice, this does break some APIs that _require_ real numeric values, so this change coerces all values to strings _then_ does a sweep for numbers, which should work as expected.