### PR TITLE
Fix pipeline json types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x (Month Day, Year)
 
 #### Fixes
+* Fix an issue with string coercion for certain fields in pipelines.
 
 #### Features
 

--- a/lib/puppet_x/elastic/deep_to_s.rb
+++ b/lib/puppet_x/elastic/deep_to_s.rb
@@ -10,7 +10,7 @@ module Puppet_X
         obj.map { |element| deep_to_s(element) }
       elsif obj.is_a? Hash
         obj.merge(obj) { |_key, val| deep_to_s(val) }
-      elsif (not obj.is_a? String) and obj.respond_to? :to_s
+      elsif (not obj.is_a? String) and (not [true, false].include?(obj)) and obj.respond_to? :to_s
         obj.to_s
       else
         obj

--- a/spec/acceptance/tests/acceptance_spec.rb
+++ b/spec/acceptance/tests/acceptance_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper_acceptance'
 require 'helpers/acceptance/tests/basic_shared_examples.rb'
 require 'helpers/acceptance/tests/template_shared_examples.rb'
 require 'helpers/acceptance/tests/removal_shared_examples.rb'
+require 'helpers/acceptance/tests/pipeline_shared_examples.rb'
 require 'helpers/acceptance/tests/plugin_shared_examples.rb'
 require 'helpers/acceptance/tests/plugin_upgrade_shared_examples.rb'
 require 'helpers/acceptance/tests/snapshot_repository_shared_examples.rb'
@@ -88,6 +89,8 @@ describe "elasticsearch v#{v[:elasticsearch_full_version]} class" do
   end
 
   include_examples('template operations', es_01, v[:template])
+
+  include_examples('pipeline operations', es_01, v[:pipeline])
 
   include_examples('plugin acceptance tests', v[:elasticsearch_plugins]) unless v[:elasticsearch_plugins].empty?
 

--- a/spec/acceptance/tests/acceptance_spec.rb
+++ b/spec/acceptance/tests/acceptance_spec.rb
@@ -90,7 +90,7 @@ describe "elasticsearch v#{v[:elasticsearch_full_version]} class" do
 
   include_examples('template operations', es_01, v[:template])
 
-  include_examples('pipeline operations', es_01, v[:pipeline])
+  include_examples('pipeline operations', es_01, v[:pipeline]) if semver(v[:elasticsearch_full_version]) >= semver('5.0.0')
 
   include_examples('plugin acceptance tests', v[:elasticsearch_plugins]) unless v[:elasticsearch_plugins].empty?
 

--- a/spec/fixtures/pipelines/example.json
+++ b/spec/fixtures/pipelines/example.json
@@ -1,0 +1,47 @@
+{
+  "description": "An example pipeline.",
+  "on_failure": [
+    {
+      "set": {
+        "field": "error",
+        "value": "{{ _ingest.on_failure_message }}"
+      }
+    }
+  ],
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "ignore_missing": true,
+        "patterns": [
+          "%{COMBINEDAPACHELOG}"
+        ]
+      }
+    },
+    {
+      "remove": {
+        "field": "message"
+      }
+    },
+    {
+      "date": {
+        "field": "read_timestamp",
+        "formats": [
+          "dd/MMM/YYYY:H:m:s Z"
+        ],
+        "target_field": "@timestamp"
+      }
+    },
+    {
+      "remove": {
+        "field": "read_timestamp"
+      }
+    },
+    {
+      "script": {
+        "lang": "painless",
+        "source": "ctx._index = 'foo';"
+      }
+    }
+  ]
+}

--- a/spec/helpers/acceptance/tests/pipeline_shared_examples.rb
+++ b/spec/helpers/acceptance/tests/pipeline_shared_examples.rb
@@ -1,0 +1,39 @@
+require 'json'
+require 'helpers/acceptance/tests/manifest_shared_examples'
+require 'helpers/acceptance/tests/bad_manifest_shared_examples'
+
+shared_examples 'pipeline operations' do |instances, pipeline|
+  describe 'pipeline resources' do
+    let(:pipeline_name) { 'foo' }
+    context 'present' do
+      let(:extra_manifest) do
+        <<-MANIFEST
+          elasticsearch::pipeline { '#{pipeline_name}':
+            ensure  => 'present',
+            content => #{pipeline}
+          }
+        MANIFEST
+      end
+
+      include_examples(
+        'manifest application',
+        instances
+      )
+
+      context 'absent' do
+        let(:extra_manifest) do
+          <<-MANIFEST
+            elasticsearch::template { '#{pipeline_name}':
+              ensure => absent,
+            }
+          MANIFEST
+        end
+
+        include_examples(
+          'manifest application',
+          instances
+        )
+      end
+    end
+  end
+end

--- a/spec/helpers/unit/type/elasticsearch_rest_shared_examples.rb
+++ b/spec/helpers/unit/type/elasticsearch_rest_shared_examples.rb
@@ -68,7 +68,7 @@ shared_examples 'REST API types' do |resource_type, meta_property|
           :name => resource_name,
           meta_property => { 'key' => { 'value' => '0', 'other' => true } }
         )[meta_property]).to include(
-          'key' => { 'value' => 0, 'other' => 'true' }
+          'key' => { 'value' => 0, 'other' => true }
         )
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,6 +33,7 @@ RSpec.configure do |c|
                      JSON.load(File.new('spec/fixtures/templates/post_6.0.json'))
                    end
     v[:template] = Puppet_X::Elastic.deep_to_i(Puppet_X::Elastic.deep_to_s(v[:template]))
+    v[:pipeline] = JSON.load(File.new('spec/fixtures/pipelines/example.json'))
 
     v[:elasticsearch_plugins] = Dir[
       artifact("*#{v[:elasticsearch_full_version]}.zip", ['plugins'])

--- a/spec/unit/type/elasticsearch_template_spec.rb
+++ b/spec/unit/type/elasticsearch_template_spec.rb
@@ -109,6 +109,8 @@ describe Puppet::Type.type(:elasticsearch_template) do
           obj.map { |element| deep_stringify(element) }
         elsif obj.is_a? Hash
           obj.merge(obj) { |_key, val| deep_stringify(val) }
+        elsif [true, false].include? obj
+          obj
         else
           obj.to_s
         end


### PR DESCRIPTION
<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

The various json parsing changes broke how booleans behave in pipelines, this adds some explicit pipeline testing acceptance tests and _should_ resolve the issue.

Related to #973 