### PR TITLE
Set download tool to verify certificates by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Fixes
 * Update puppetlabs-stdlib dependency to < 6.0.0
+* By default, package files downloaded with tools like wget or curl (i.e., the `$elasticsearch::download_tool parameter`) now verify certificates by default and a new boolean parameter has been added to indicate whether to ignore certificates (`$elasticsearch::download_tool_verify_certificates`).
 
 #### Features
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,6 +17,8 @@ elasticsearch::datadir_instance_directories: true
 elasticsearch::default_logging_level: 'INFO'
 elasticsearch::defaults_location: ~
 elasticsearch::download_tool: ~
+elasticsearch::download_tool_insecure: ~
+elasticsearch::download_tool_verify_certificates: true
 elasticsearch::file_rolling_type: dailyRollingFile
 elasticsearch::indices: {}
 elasticsearch::init_defaults: {}

--- a/data/kernel/Darwin.yaml
+++ b/data/kernel/Darwin.yaml
@@ -1,4 +1,5 @@
 ---
-elasticsearch::download_tool: 'curl --insecure -o'
+elasticsearch::download_tool: curl -o
+elasticsearch::download_tool_insecure: curl --insecure -o
 elasticsearch::elasticsearch_user: elasticsearch
 elasticsearch::elasticsearch_group: elasticsearch

--- a/data/kernel/Linux.yaml
+++ b/data/kernel/Linux.yaml
@@ -1,6 +1,7 @@
 ---
 elasticsearch::datadir: /var/lib/elasticsearch
-elasticsearch::download_tool: 'wget --no-check-certificate -O'
+elasticsearch::download_tool: wget -O
+elasticsearch::download_tool_insecure: wget --no-check-certificate -O
 elasticsearch::elasticsearch_user: elasticsearch
 elasticsearch::elasticsearch_group: elasticsearch
 elasticsearch::homedir: /usr/share/elasticsearch

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,14 @@
 # @param download_tool
 #   Command-line invocation with which to retrieve an optional package_url.
 #
+# @param download_tool_insecure
+#   Command-line invocation with which to retrieve an optional package_url when
+#   certificate verification should be ignored.
+#
+# @param download_tool_verify_certificates
+#   Whether or not to verify SSL/TLS certificates when retrieving package files
+#   using a download tool instead of a package management provider.
+#
 # @param elasticsearch_group
 #   The group Elasticsearch should run as. This also sets file group
 #   permissions.
@@ -307,6 +315,8 @@ class elasticsearch (
   String                                          $default_logging_level,
   Optional[Stdlib::Absolutepath]                  $defaults_location,
   Optional[String]                                $download_tool,
+  Optional[String]                                $download_tool_insecure,
+  Boolean                                         $download_tool_verify_certificates,
   String                                          $elasticsearch_group,
   String                                          $elasticsearch_user,
   Enum['dailyRollingFile', 'rollingFile', 'file'] $file_rolling_type,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -105,8 +105,14 @@ class elasticsearch::package {
 
           case $elasticsearch::download_tool {
             String: {
+              $_download_command = if $elasticsearch::download_tool_verify_certificates {
+                $elasticsearch::download_tool
+              } else {
+                $elasticsearch::download_tool_insecure
+              }
+
               exec { 'download_package_elasticsearch':
-                command     => "${elasticsearch::download_tool} ${pkg_source} ${elasticsearch::package_url} 2> /dev/null",
+                command     => "${_download_command} ${pkg_source} ${elasticsearch::package_url} 2> /dev/null",
                 creates     => $pkg_source,
                 environment => $exec_environment,
                 timeout     => $elasticsearch::package_dl_timeout,

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -170,9 +170,9 @@ describe 'elasticsearch', :type => 'class' do
                     flag = (not verify_certificates) ? ' --no-check-certificate' : ''
 
                     it { should contain_exec('download_package_elasticsearch')
-                        .with(
-                          :command => "wget#{flag} -O /opt/elasticsearch/swdl/pkg.#{pkg_ext} #{schema}domain-or-path/pkg.#{pkg_ext} 2> /dev/null",
-                          :require => 'File[/opt/elasticsearch/swdl]'
+                      .with(
+                        :command => "wget#{flag} -O /opt/elasticsearch/swdl/pkg.#{pkg_ext} #{schema}domain-or-path/pkg.#{pkg_ext} 2> /dev/null",
+                        :require => 'File[/opt/elasticsearch/swdl]'
                       ) }
                   end
                 end

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -158,11 +158,24 @@ describe 'elasticsearch', :type => 'class' do
                   :backup => false
                 ) }
               else
-                it { should contain_exec('download_package_elasticsearch')
-                  .with(
-                    :command => "wget --no-check-certificate -O /opt/elasticsearch/swdl/pkg.#{pkg_ext} #{schema}domain-or-path/pkg.#{pkg_ext} 2> /dev/null",
-                    :require => 'File[/opt/elasticsearch/swdl]'
-                  ) }
+                [true, false].each do |verify_certificates|
+                  context "with download_tool_verify_certificates '#{verify_certificates}'" do
+                    let(:params) do
+                      default_params.merge(
+                        :package_url => "#{schema}domain-or-path/pkg.#{pkg_ext}",
+                        :download_tool_verify_certificates => verify_certificates
+                      )
+                    end
+
+                    flag = (not verify_certificates) ? ' --no-check-certificate' : ''
+
+                    it { should contain_exec('download_package_elasticsearch')
+                        .with(
+                          :command => "wget#{flag} -O /opt/elasticsearch/swdl/pkg.#{pkg_ext} #{schema}domain-or-path/pkg.#{pkg_ext} 2> /dev/null",
+                          :require => 'File[/opt/elasticsearch/swdl]'
+                      ) }
+                  end
+                end
               end
 
               it { should contain_package('elasticsearch')


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Invocations to curl/wget should be secure by default, but configurable to ignore certificate errors if desired.