### PR TITLE
Remove _default_ mapping for type deprecations

### DIFF
--- a/spec/fixtures/templates/post_6.0.json
+++ b/spec/fixtures/templates/post_6.0.json
@@ -15,7 +15,7 @@
     }
   },
   "mappings": {
-    "_default_": {
+    "_doc": {
       "dynamic_templates": [
         {
           "string_fields": {


### PR DESCRIPTION
Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)

Just fixes some failing tests against snapshot versions of ES.