### PR TITLE
undefined method `mask' for Service[elasticsearch] #1007

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,8 +102,8 @@ class elasticsearch::config {
     if ($elasticsearch::service_provider == 'systemd') {
       # Mask default unit (from package)
       service { 'elasticsearch' :
-        ensure => false,
-        enable => 'mask',
+        ensure   => false,
+        enable   => 'mask',
         provider => $elasticsearch::service_provider,
       }
     } else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,6 +104,7 @@ class elasticsearch::config {
       service { 'elasticsearch' :
         ensure => false,
         enable => 'mask',
+        provider => $elasticsearch::service_provider,
       }
     } else {
       service { 'elasticsearch':


### PR DESCRIPTION
Fixes "undefined method `mask' for Service[elasticsearch]" #1007