### PR TITLE
Properly handle when instance and class set to absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Puppet 4.10.0 is the new minimum required version of Puppet.
 #### Fixes
 * The Elasticsearch log directory is no longer recursively managed to avoid stomping on the user/mode settings that Elasticsearch prefers.
 * Package management on apt-based systems no longer encounters dependency errors when `manage_repo => false`.
+* Correctly permit instances to be set to `absent` without errors.
 
 #### Features
 

--- a/lib/puppet/provider/elasticsearch_service_file/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_service_file/ruby.rb
@@ -63,9 +63,18 @@ Puppet::Type.type(:elasticsearch_service_file).provide(:ruby) do
   end
 
   def flush
-    opt_flag, opt_flags = Puppet_X::Elastic::EsVersioning.opt_flags(
-      resource[:package_name], resource.catalog
-    )
+    begin
+      opt_flag, opt_flags = Puppet_X::Elastic::EsVersioning.opt_flags(
+        resource[:package_name], resource.catalog
+      )
+    rescue ElasticsearchPackageNotFoundError
+      # If the Elasticsearch package is not present at all, we don't know what
+      # version is present, so we just set these as empty values for the
+      # template.
+      opt_flag = ''
+      opt_flags = []
+    end
+
     # This should only be present on systemd systems.
     opt_flags.delete('--quiet') unless resource[:name].include?('systemd')
 

--- a/lib/puppet/type/elasticsearch_service_file.rb
+++ b/lib/puppet/type/elasticsearch_service_file.rb
@@ -29,6 +29,15 @@ Puppet::Type.newtype(:elasticsearch_service_file) do
 
       template = ERB.new(should, 0, '-')
       is == template.result(binding)
+    rescue ElasticsearchPackageNotFoundError
+      # This behavior is extremely confusing because of the fact that while
+      # someone should be able to indicate that an instance should be absent,
+      # if there is no service file to query via Puppet providers, it can't
+      # determine this fact. If no package exists and thus `absent` has been
+      # instructed, indicate that the template contents are correct, because
+      # we don't really care what's in there anyway - the service file is for
+      # an absent instance of Elasticsearch anyway.
+      return true
     end
 
     # Represent as a checksum, not the whole file

--- a/spec/helpers/acceptance/tests/removal_shared_examples.rb
+++ b/spec/helpers/acceptance/tests/removal_shared_examples.rb
@@ -17,6 +17,10 @@ shared_examples 'module removal' do |instances|
       apply_manifest manifest, :catch_failures => true
     end
 
+    it 'is idempotent' do
+      apply_manifest manifest, :catch_changes => true
+    end
+
     instances.each do |instance|
       describe file("/etc/elasticsearch/#{instance}") do
         it { should_not be_directory }


### PR DESCRIPTION
Previously, when setting instances and the Elasticsearch class to absent, errors like #967 are thrown. This lets the module set these resources to `absent` without exceptions being thrown.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
