### PR TITLE
Properly return objects in sorted hash each_pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Puppet 4.10.0 is the new minimum required version of Puppet.
 #### Fixes
 * The Elasticsearch log directory is no longer recursively managed to avoid stomping on the user/mode settings that Elasticsearch prefers.
 * Package management on apt-based systems no longer encounters dependency errors when `manage_repo => false`.
+* An error related to elasticsearch_roles and `yield` errors has been fixed
 
 #### Features
 

--- a/lib/puppet_x/elastic/hash.rb
+++ b/lib/puppet_x/elastic/hash.rb
@@ -64,9 +64,11 @@ module Puppet_X
       # Override each_pair with a method that yields key/values in
       # sorted order.
       def each_pair
+        return to_enum(:each_pair) unless block_given?
         keys.sort.each do |key|
           yield key, self[key]
         end
+        self
       end
     end
   end

--- a/spec/unit/puppet_x/elastic/hash_spec.rb
+++ b/spec/unit/puppet_x/elastic/hash_spec.rb
@@ -1,0 +1,25 @@
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
+
+require 'spec_helper_rspec'
+require 'puppet_x/elastic/hash'
+
+describe Puppet_X::Elastic::SortedHash do
+  subject { { 'foo' => 1, 'bar' => 2 } }
+
+  describe 'each_pair' do
+    it { is_expected.to respond_to :each_pair }
+
+    it 'yields values' do
+      expect { |b| subject.each_pair(&b) }.to yield_control.exactly(2).times
+    end
+
+    it 'returns an Enumerator if not passed a block' do
+      expect(subject.each_pair).to be_an_instance_of(Enumerator)
+    end
+
+    it 'returns values' do
+      subject.each_pair.map { |k, v| [k, v] }.should == subject.to_a
+    end
+  end
+end


### PR DESCRIPTION
The custom guaranteed-order hash class this module uses causes some errors within some other Puppet machinery as seen in #1013. This resolves those errors.

---

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
