### PR TITLE
Solution for error: Could not autoload puppet/type/elasticsearch_user

### DIFF
--- a/lib/puppet/provider/elasticsearch_user/elasticsearch_users.rb
+++ b/lib/puppet/provider/elasticsearch_user/elasticsearch_users.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+
 require 'puppet/provider/elastic_user_command'
 
 Puppet::Type.type(:elasticsearch_user).provide(


### PR DESCRIPTION
Hello

PR contains solution for error ```Could not find a suitable provider for elasticsearch_role/elasticsearch_user_roles
Could not autoload puppet/type/elasticsearch_user
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Virtual Query, Could not autoload puppet/type/elasticsearch_user: Could not autoload puppet/provider/elasticsearch_user/elasticsearch_users: no such file to load -- puppet/provider/elastic_user_command```