### PR TITLE
[ci] add JJBB definitions

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,53 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: devops-ci
+
+##### JOB DEFAULTS
+
+- job:
+    project-type: matrix
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 100
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    properties:
+    - github:
+        url: https://github.com/elastic/puppet-elasticsearch/
+    - inject:
+        properties-content: |-
+          HOME=$JENKINS_HOME
+          VAULT_PATH=secret/devops-ci/puppet-elasticsearch/xpack_license
+    node: master
+    scm:
+    - git:
+        name: origin
+        credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        reference-repo: /var/lib/jenkins/.git-references/puppet-elasticsearch.git
+        branches:
+        - ${branch_specifier}
+        url: https://github.com/elastic/puppet-elasticsearch.git
+        basedir: ''
+        wipe-workspace: 'True'
+    triggers:
+    - github
+    vault:
+      url: https://secrets.elastic.co:8200
+      role_id: cff5d4e0-61bf-2497-645f-fcf019d10c13
+    wrappers:
+    - ansicolor
+    - timeout:
+        type: absolute
+        timeout: 360
+        fail: true
+    - timestamps
+    publishers:
+    - email:
+        recipients: infra-root+build@elastic.co

--- a/.ci/jobs/elastic+puppet-elasticsearch+master+acceptance.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+master+acceptance.yml
@@ -1,0 +1,46 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+master+acceptance
+    display-name: elastic / puppet-elasticsearch - master - acceptance
+    description: Master - acceptance
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: OS
+        filename: spec/matrix.yml
+        type: yaml
+    - axis:
+        name: TEST_TYPE
+        filename: spec/matrix.yml
+        type: yaml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        # We need to not use [VERSION] in the matrix name since having
+        # square brackets in the directories breaks some of the puppet tests
+        case "$TEST_TYPE" in
+        latest)
+        test=acceptance
+        ;;
+        snapshot)
+        test=snapshot
+        ;;
+        *)
+        test="acceptance[$TEST_TYPE]"
+        ;;
+        esac
+
+        echo '--color' >> ~/.rspec
+        bundle install
+        bundle exec rake "beaker:$OS:$test"

--- a/.ci/jobs/elastic+puppet-elasticsearch+master+intake.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+master+intake.yml
@@ -1,0 +1,28 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+master+intake
+    display-name: elastic / puppet-elasticsearch - master - intake
+    description: Master - intake
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: PUPPET_VERSION
+        filename: spec/matrix.yml
+        type: yaml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        echo '--color' >> ~/.rspec
+        bundle install
+        bundle exec rake intake

--- a/.ci/jobs/elastic+puppet-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+master.yml
@@ -1,0 +1,22 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+master
+    display-name: elastic / puppet-elasticsearch - master
+    description: Master branch testing
+    project-type: multijob
+    scm:
+    - git:
+        wipe-workspace: 'False'
+    triggers:
+    - timed: H H(02-04) * * *
+    builders:
+    - multijob:
+        name: intake phase
+        projects:
+        - name: elastic+puppet-elasticsearch+master+intake
+          predefined-parameters: branch_specifier=master
+    - multijob:
+        name: acceptance phase
+        projects:
+        - name: elastic+puppet-elasticsearch+master+acceptance
+          predefined-parameters: branch_specifier=master

--- a/.ci/jobs/elastic+puppet-elasticsearch+pull-request+acceptance.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+pull-request+acceptance.yml
@@ -1,0 +1,49 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+pull-request+acceptance
+    display-name: elastic / puppet-elasticsearch - pull-request - acceptance
+    description: Pull request testing - acceptance
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: OS
+        filename: spec/matrix.yml
+        type: yaml
+    - axis:
+        name: TEST_TYPE
+        filename: spec/matrix.yml
+        type: yaml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        # We need to not use [VERSION] in the matrix name since having
+        # square brackets in the directories breaks some of the puppet tests
+        case "$TEST_TYPE" in
+        latest)
+        test=acceptance
+        ;;
+        snapshot)
+        test=snapshot
+        ;;
+        *)
+        test="acceptance[$TEST_TYPE]"
+        ;;
+        esac
+
+        echo '--color' >> ~/.rspec
+        bundle install
+        bundle exec rake "beaker:$OS:$test"

--- a/.ci/jobs/elastic+puppet-elasticsearch+pull-request+intake.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+pull-request+intake.yml
@@ -1,0 +1,31 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+pull-request+intake
+    display-name: elastic / puppet-elasticsearch - pull-request - intake
+    description: Pull request testing - intake
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: PUPPET_VERSION
+        filename: spec/matrix.yml
+        type: yaml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        echo '--color' >> ~/.rspec
+        bundle install
+        bundle exec rake intake

--- a/.ci/jobs/elastic+puppet-elasticsearch+pull-request.yml
+++ b/.ci/jobs/elastic+puppet-elasticsearch+pull-request.yml
@@ -1,0 +1,31 @@
+---
+- job:
+    name: elastic+puppet-elasticsearch+pull-request
+    display-name: elastic / puppet-elasticsearch - pull-request
+    description: Pull request testing
+    project-type: multijob
+    scm:
+    - git:
+        branches:
+        - $ghprbActualCommit
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+        wipe-workspace: 'False'
+    triggers:
+    - github-pull-request:
+        github-hooks: true
+        org-list:
+        - elastic
+        allow-whitelist-orgs-as-admins: true
+        cancel-builds-on-update: false
+        status-context: devops-ci
+    builders:
+    - multijob:
+        name: intake phase
+        projects:
+        - name: elastic+puppet-elasticsearch+pull-request+intake
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+    - multijob:
+        name: acceptance phase
+        projects:
+        - name: elastic+puppet-elasticsearch+pull-request+acceptance
+          predefined-parameters: branch_specifier=${ghprbActualCommit}


### PR DESCRIPTION
Add JJBB definitions to the repo so they can be managed here.

* Enable auto-generation of `inject-passwords` section

* Move `VAULT_PATH` to a plain environmental variable since we don't
currently support auto-generation of `inject-passwords` and "extra"
attributes.

* Note that the publisher `infra-root+build@elastic.co` is now the
default, so it'll be used for any jobs that don't override it. Let me
know if that's not what we want and I'll update.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)