### PR TITLE
[ci] remove vault url from defaults

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -39,7 +39,6 @@
     triggers:
     - github
     vault:
-      url: https://secrets.elastic.co:8200
       role_id: cff5d4e0-61bf-2497-645f-fcf019d10c13
     wrappers:
     - ansicolor


### PR DESCRIPTION
We moved this default inside JJBB itself so it's not necessary to have
it in the defaults file anymore.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)