### PR TITLE
Explicitely set systemd service permission

### DIFF
--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -179,6 +179,7 @@ define elasticsearch::service::systemd (
       ensure => 'file',
       owner  => 'root',
       group  => 'root',
+      mode   => '0644',
       before => Service["elasticsearch-instance-${name}"],
       notify => $notify_service,
     }


### PR DESCRIPTION
The configuration happends to default to 0600, resulting in systemd
producing this warning message:

```
Configuration file /usr/lib/systemd/system/elasticsearch-es-01.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
```

Set read permission for group and others to fix this issue.

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Tests pass
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
