### PR TITLE
Allow puppetlabs/stdlib 6.x and puppet 6.x.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "elastic/elastic_stack",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     },
     {
       "name": "richardc/datacat",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 6.0.0"
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -80,7 +80,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Tests appear to be broken.