### PR TITLE
add s3 support for respository

### DIFF
--- a/lib/puppet/provider/elasticsearch_snapshot_repository/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_snapshot_repository/ruby.rb
@@ -21,6 +21,8 @@ Puppet::Type.type(:elasticsearch_snapshot_repository).provide(
         :type              => api_object['type'],
         :compress          => api_object['settings']['compress'],
         :location          => api_object['settings']['location'],
+        :bucket            => api_object['settings']['bucket'],
+        :region            => api_object['settings']['region'],
         :chunk_size        => api_object['settings']['chunk_size'],
         :max_restore_rate  => api_object['settings']['max_restore_rate'],
         :max_snapshot_rate => api_object['settings']['max_snapshot_rate'],
@@ -36,13 +38,15 @@ Puppet::Type.type(:elasticsearch_snapshot_repository).provide(
     body = {
       'type'     => resource[:type],
       'settings' => {
-        'compress' => resource[:compress],
-        'location' => resource[:location]
+        'compress' => resource[:compress]
       }
     }
 
     # Add optional values
     body['settings']['chunk_size'] = resource[:chunk_size] unless resource[:chunk_size].nil?
+    body['settings']['location'] = resource[:location] unless resource[:location].nil?
+    body['settings']['bucket'] = resource[:bucket] unless resource[:bucket].nil?
+    body['settings']['region'] = resource[:region] unless resource[:region].nil?
     body['settings']['max_restore_rate'] = resource[:max_restore_rate] unless resource[:max_restore_rate].nil?
     body['settings']['max_snapshot_rate'] = resource[:max_snapshot_rate] unless resource[:max_snapshot_rate].nil?
 

--- a/lib/puppet/type/elasticsearch_snapshot_repository.rb
+++ b/lib/puppet/type/elasticsearch_snapshot_repository.rb
@@ -33,6 +33,14 @@ Puppet::Type.newtype(:elasticsearch_snapshot_repository) do
     desc 'Repository location'
   end
 
+  newproperty(:bucket) do
+    desc 'S3 bucket'
+  end
+
+  newproperty(:region) do
+    desc 'S3 region'
+  end
+
   newproperty(:chunk_size) do
     desc 'File chunk size'
   end
@@ -46,6 +54,10 @@ Puppet::Type.newtype(:elasticsearch_snapshot_repository) do
   end
 
   validate do
-    raise ArgumentError, 'Location is required.' if self[:location].nil?
+    if self[:type] == 'fs'
+      raise ArgumentError, 'Location is required.' if self[:location].nil?
+    elsif self[:type] == 's3'
+      raise ArgumentError, 'Bucket is required.' if self[:bucket].nil?
+    end
   end
 end # of newtype

--- a/manifests/snapshot_repository.pp
+++ b/manifests/snapshot_repository.pp
@@ -37,7 +37,13 @@
 #   Snapshot repository type.
 #
 # @param location
-#   Location of snapshots. Mandatory
+#   Location of snapshots.
+#
+# @param region
+#   The S3 region of the bucket to be used for snapshots.
+#
+# @param bucket
+#   The S3 name of the bucket to be used for snapshots.
 #
 # @param compress
 #   Compress the snapshot metadata files?
@@ -60,8 +66,10 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::snapshot_repository (
-  String                          $location,
+  Optional[String]                $location                = undef,
   Enum['absent', 'present']       $ensure                  = 'present',
+  Optional[String]                $bucket                  = undef,
+  Optional[String]                $region                  = undef,
   Optional[String]                $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
   Optional[String]                $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
   Optional[Stdlib::Absolutepath]  $api_ca_file             = $elasticsearch::api_ca_file,
@@ -88,6 +96,8 @@ define elasticsearch::snapshot_repository (
     chunk_size        => $chunk_size,
     compress          => $compress,
     location          => $location,
+    region            => $region,
+    bucket            => $bucket,
     max_restore_rate  => $max_restore_rate,
     max_snapshot_rate => $max_snapshot_rate,
     type              => $repository_type,


### PR DESCRIPTION
This PR adds support to manage s3 repository.

Example:
```
    elasticsearch::snapshot_repository {  's3_repository':
      repository_type => 's3',
      bucket          => $backup_aws_s3_bucket,
      region          => $backup_aws_s3_region
    }
```
