### PR TITLE
Accept Puppet-Datatype Sensitive

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -202,11 +202,15 @@ class elasticsearch::config {
 
     # Add secrets to keystore
     if $elasticsearch::secrets != undef {
+      # unwrap Secrets of Datatype Sensitive
+      $secrets = $elasticsearch::secrets.reduce({}) |Hash $memo, Array $value| {
+        $memo + { $value[0] => if $value[1] =~ Sensitive { $value[1].unwrap } else { $value[1] } }
+      }
       elasticsearch_keystore { 'elasticsearch_secrets':
         configdir => $elasticsearch::configdir,
         purge     => $elasticsearch::purge_secrets,
-        settings  => $elasticsearch::secrets,
-        notify    => $::elaticsearch::_notify_service,
+        settings  => $secrets,
+        notify    => $::elasticsearch::_notify_service,
       }
     }
 


### PR DESCRIPTION
- let the Hash containing the Secrets for the Keystore accept Secrets of Datatype Sensitive
- fix a 15-Months-old Typo-Bug

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [ ] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [ ] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
