### PR TITLE
fix elasticsearch/user: allow ensure=absent without password

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2179,12 +2179,14 @@ Default value: `'present'`
 
 ##### <a name="-elasticsearch--user--password"></a>`password`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Password for the given user. A plaintext password will be managed
 with the esusers utility and requires a refresh to update, while
 a hashed password from the esusers utility will be managed manually
 in the uses file.
+
+Default value: `undef`
 
 ##### <a name="-elasticsearch--user--roles"></a>`roles`
 

--- a/spec/defines/007_elasticsearch_user_spec.rb
+++ b/spec/defines/007_elasticsearch_user_spec.rb
@@ -86,6 +86,31 @@ describe 'elasticsearch::user' do
 
         include_examples 'class', :systemd
       end
+
+      context "with ensure => 'absent' and no password" do
+        let(:params) do
+          {
+            ensure: 'absent',
+            roles: []
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          expect(subject).to contain_elasticsearch_user('elastic').with(
+            'ensure' => 'absent',
+            'configdir' => '/etc/elasticsearch'
+          )
+        end
+
+        it do
+          expect(subject).to contain_elasticsearch_user_roles('elastic').with(
+            'ensure' => 'absent',
+            'roles' => []
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Pull Request (PR) description**
Removing a user previously failed because the elasticsearch::user define always required and passed a password, even when ensure => absent.

This PR fixes the issue by making the password parameter optional and improving the logic for handling user removal.

**Related Issue**
Fixes [#1264](https://github.com/voxpupuli/puppet-elasticsearch/issues/1264?utm_source=chatgpt.com)

**Changes:**

- File: manifests/user.pp
   - Make password an Optional[String].
  - When ensure => absent, declare elasticsearch_user with ensure => absent and do not pass a password.
  - Add validation to enforce that a password must be provided when ensure => present.
